### PR TITLE
Add HACS badge to README for easier integration installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ This minimizes your total energy cost over a configurable time horizon (default 
 
 ### HACS Installation (Recommended)
 
+[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=ha-energy-optimiser&repository=haeo&category=integration)
+
 1. Open HACS in your Home Assistant instance
 2. Click on "Integrations"
 3. Click the three dots in the top right corner


### PR DESCRIPTION
This pull request adds a Home Assistant Community Store (HACS) badge to the `README.md` file to improve visibility and make it easier for users to access the integration repository directly from their Home Assistant instance. No functional code changes are included.