### PR TITLE
Make the forecast loaders also accept datetime objects

### DIFF
--- a/custom_components/haeo/data/loader/extractors/aemo_nem.py
+++ b/custom_components/haeo/data/loader/extractors/aemo_nem.py
@@ -1,13 +1,13 @@
 """AEMO energy market forecast parser."""
 
 from collections.abc import Sequence
-from datetime import datetime
 import logging
 from typing import Any, Literal
 
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.core import State
-from homeassistant.util.dt import as_utc
+
+from .datetime_utils import parse_datetime_to_timestamp
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -21,15 +21,14 @@ def _parse_entry(item: Any) -> tuple[int, float] | None:
     if not isinstance(item, dict):
         return None
 
-    start_time_str = item.get("start_time")
+    start_time = item.get("start_time")
     price = item.get("price")
 
-    if not isinstance(start_time_str, str) or price is None:
+    if start_time is None or price is None:
         return None
 
     try:
-        dt = as_utc(datetime.fromisoformat(start_time_str))
-        timestamp_seconds = int(dt.timestamp())
+        timestamp_seconds = parse_datetime_to_timestamp(start_time)
         value = float(price)
     except (ValueError, TypeError):
         return None

--- a/custom_components/haeo/data/loader/extractors/amberelectric.py
+++ b/custom_components/haeo/data/loader/extractors/amberelectric.py
@@ -1,13 +1,13 @@
 """Amber Electric (amberelectric) pricing forecast parser."""
 
 from collections.abc import Sequence
-from datetime import datetime
 import logging
 from typing import Any, Literal
 
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.core import State
-from homeassistant.util.dt import as_utc
+
+from .datetime_utils import parse_datetime_to_timestamp
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -21,15 +21,14 @@ def _parse_entry(item: Any) -> tuple[int, float] | None:
     if not isinstance(item, dict):
         return None
 
-    start_time_str = item.get("start_time")
+    start_time = item.get("start_time")
     per_kwh = item.get("per_kwh")
 
-    if not isinstance(start_time_str, str) or per_kwh is None:
+    if start_time is None or per_kwh is None:
         return None
 
     try:
-        dt = as_utc(datetime.fromisoformat(start_time_str))
-        timestamp_seconds = int(dt.timestamp())
+        timestamp_seconds = parse_datetime_to_timestamp(start_time)
         value = float(per_kwh)
     except (ValueError, TypeError):
         return None

--- a/custom_components/haeo/data/loader/extractors/datetime_utils.py
+++ b/custom_components/haeo/data/loader/extractors/datetime_utils.py
@@ -1,0 +1,33 @@
+"""Utility functions for datetime parsing in forecast extractors."""
+
+from datetime import datetime
+from typing import Any
+
+from homeassistant.util.dt import as_utc
+
+
+def parse_datetime_to_timestamp(value: Any) -> int:
+    """Parse a datetime string or datetime object to UTC timestamp.
+
+    Args:
+        value: Either a datetime object or an ISO format datetime string
+
+    Returns:
+        Unix timestamp in seconds
+
+    Raises:
+        ValueError: If value is not a valid datetime string or datetime object
+
+    """
+    # Handle datetime objects directly
+    if isinstance(value, datetime):
+        dt = as_utc(value)
+        return int(dt.timestamp())
+
+    # Handle string datetime values
+    if isinstance(value, str):
+        dt = as_utc(datetime.fromisoformat(value))
+        return int(dt.timestamp())
+
+    msg = f"Expected datetime or string, got {type(value).__name__}"
+    raise ValueError(msg)

--- a/custom_components/haeo/data/loader/extractors/open_meteo_solar_forecast.py
+++ b/custom_components/haeo/data/loader/extractors/open_meteo_solar_forecast.py
@@ -1,14 +1,14 @@
 """Open-Meteo solar forecast parser."""
 
 from collections.abc import Sequence
-from datetime import datetime
 import logging
 from typing import Any, Literal
 
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.const import UnitOfPower
 from homeassistant.core import State
-from homeassistant.util.dt import as_utc
+
+from .datetime_utils import parse_datetime_to_timestamp
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -16,15 +16,11 @@ Format = Literal["open_meteo_solar_forecast"]
 DOMAIN: Format = "open_meteo_solar_forecast"
 
 
-def _parse_entry(time_str: Any, power_value: Any) -> tuple[int, float] | None:
+def _parse_entry(time_value: Any, power_value: Any) -> tuple[int, float] | None:
     """Validate and convert a forecast entry."""
 
-    if not isinstance(time_str, str):
-        return None
-
     try:
-        dt = as_utc(datetime.fromisoformat(time_str))
-        timestamp_seconds = int(dt.timestamp())
+        timestamp_seconds = parse_datetime_to_timestamp(time_value)
         value = float(power_value)
     except (ValueError, TypeError):
         return None

--- a/custom_components/haeo/data/loader/extractors/solcast_solar.py
+++ b/custom_components/haeo/data/loader/extractors/solcast_solar.py
@@ -1,14 +1,14 @@
 """Solcast solar forecast parser."""
 
 from collections.abc import Sequence
-from datetime import datetime
 import logging
 from typing import Any, Literal
 
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.const import UnitOfPower
 from homeassistant.core import State
-from homeassistant.util.dt import as_utc
+
+from .datetime_utils import parse_datetime_to_timestamp
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -22,15 +22,14 @@ def _parse_entry(item: Any) -> tuple[int, float] | None:
     if not isinstance(item, dict):
         return None
 
-    period_start_str = item.get("period_start")
+    period_start = item.get("period_start")
     pv_estimate = item.get("pv_estimate")
 
-    if not isinstance(period_start_str, str) or pv_estimate is None:
+    if period_start is None or pv_estimate is None:
         return None
 
     try:
-        dt = as_utc(datetime.fromisoformat(period_start_str))
-        timestamp_seconds = int(dt.timestamp())
+        timestamp_seconds = parse_datetime_to_timestamp(period_start)
         value = float(pv_estimate)
     except (ValueError, TypeError):
         return None

--- a/tests/data/loader/extractors/test_datetime_utils.py
+++ b/tests/data/loader/extractors/test_datetime_utils.py
@@ -1,0 +1,54 @@
+"""Tests for datetime_utils module."""
+
+from datetime import UTC, datetime
+
+import pytest
+
+from custom_components.haeo.data.loader.extractors.datetime_utils import parse_datetime_to_timestamp
+
+
+def test_parse_datetime_string() -> None:
+    """Test parsing ISO format datetime strings."""
+    result = parse_datetime_to_timestamp("2025-10-06T00:00:00+11:00")
+    assert isinstance(result, int)
+    # Account for the +11:00 offset (00:00 +11:00 is 13:00 UTC previous day)
+    assert result == int(datetime(2025, 10, 5, 13, 0, 0, tzinfo=UTC).timestamp())
+
+
+def test_parse_datetime_object() -> None:
+    """Test parsing datetime objects directly."""
+    dt = datetime(2025, 10, 6, 0, 0, 0, tzinfo=UTC)
+    result = parse_datetime_to_timestamp(dt)
+    assert isinstance(result, int)
+    assert result == int(dt.timestamp())
+
+
+def test_parse_datetime_object_no_timezone() -> None:
+    """Test parsing naive datetime objects (no timezone info)."""
+    dt = datetime(2025, 10, 6, 12, 30, 0, tzinfo=UTC)
+    result = parse_datetime_to_timestamp(dt)
+    assert isinstance(result, int)
+
+
+def test_parse_invalid_string_raises_error() -> None:
+    """Test that invalid datetime strings raise ValueError."""
+    with pytest.raises(ValueError, match="Invalid isoformat string"):
+        parse_datetime_to_timestamp("not a timestamp")
+
+
+def test_parse_none_raises_error() -> None:
+    """Test that None input raises ValueError."""
+    with pytest.raises(ValueError, match="Expected datetime or string, got NoneType"):
+        parse_datetime_to_timestamp(None)
+
+
+def test_parse_non_datetime_type_raises_error() -> None:
+    """Test that non-datetime, non-string types raise ValueError."""
+    with pytest.raises(ValueError, match="Expected datetime or string, got int"):
+        parse_datetime_to_timestamp(12345)
+
+    with pytest.raises(ValueError, match="Expected datetime or string, got list"):
+        parse_datetime_to_timestamp([])
+
+    with pytest.raises(ValueError, match="Expected datetime or string, got dict"):
+        parse_datetime_to_timestamp({})

--- a/tests/test_data/sensors/amberelectric.py
+++ b/tests/test_data/sensors/amberelectric.py
@@ -1,5 +1,6 @@
 """Test data for Amber Electric forecast sensors."""
 
+from datetime import UTC, datetime
 from typing import Any
 
 # Valid Amber sensor configurations
@@ -59,6 +60,25 @@ VALID: list[dict[str, Any]] = [
         "expected_format": "amberelectric",
         "expected_count": 1,
         "description": "Amber forecast with timezone conversion",
+    },
+    {
+        "entity_id": "sensor.amber_datetime_objects",
+        "state": "0.13",
+        "attributes": {
+            "forecasts": [
+                {
+                    "per_kwh": 0.13,
+                    "start_time": datetime(2025, 10, 5, 11, 0, 0, tzinfo=UTC),
+                },
+                {
+                    "per_kwh": 0.16,
+                    "start_time": datetime(2025, 10, 5, 11, 30, 0, tzinfo=UTC),
+                },
+            ]
+        },
+        "expected_format": "amberelectric",
+        "expected_count": 2,
+        "description": "Amber forecast with datetime objects instead of strings",
     },
 ]
 

--- a/tests/test_data/sensors/solcast.py
+++ b/tests/test_data/sensors/solcast.py
@@ -1,5 +1,6 @@
 """Test data for Solcast Solar forecast sensors."""
 
+from datetime import UTC, datetime
 from typing import Any
 
 # Valid Solcast sensor configurations
@@ -37,6 +38,44 @@ VALID: list[dict[str, Any]] = [
         "expected_format": "solcast_solar",
         "expected_count": 2,
         "description": "Multiple Solcast forecast entries",
+    },
+    {
+        "entity_id": "sensor.solcast_datetime_objects",
+        "state": "0",
+        "attributes": {
+            "detailedForecast": [
+                {
+                    "period_start": datetime(2025, 10, 6, 0, 0, 0, tzinfo=UTC),
+                    "pv_estimate": 5,
+                },
+                {
+                    "period_start": datetime(2025, 10, 6, 0, 30, 0, tzinfo=UTC),
+                    "pv_estimate": 15,
+                },
+            ]
+        },
+        "expected_format": "solcast_solar",
+        "expected_count": 2,
+        "description": "Solcast forecast with datetime objects instead of strings",
+    },
+    {
+        "entity_id": "sensor.solcast_mixed_datetime_types",
+        "state": "0",
+        "attributes": {
+            "detailedForecast": [
+                {
+                    "period_start": "2025-10-06T00:00:00+11:00",
+                    "pv_estimate": 3,
+                },
+                {
+                    "period_start": datetime(2025, 10, 6, 1, 0, 0, tzinfo=UTC),
+                    "pv_estimate": 8,
+                },
+            ]
+        },
+        "expected_format": "solcast_solar",
+        "expected_count": 2,
+        "description": "Solcast forecast with mixed string and datetime object timestamps",
     },
 ]
 


### PR DESCRIPTION
Currently the solcast detection doesn't detect solcast properly as while in the serialised test code it was iso date strings, in the actual home assistant instance it's a datetime object.

That meant that the tests all passed while the actual real running HA instance couldn't find solcast forecasts.

This fixes it so that all the forecast parsers just take the outputs that could be datetime objects and accept either an ISO string or a datetime object.