### PR TITLE
Add missing change to gitignore file for the branding script

### DIFF
--- a/docs/assets/branding/.gitignore
+++ b/docs/assets/branding/.gitignore
@@ -1,2 +1,3 @@
 *
 !.gitignore
+!make_branding_pngs.py


### PR DESCRIPTION
This pull request makes a small update to the `.gitignore` file in the `docs/assets/branding` directory to ensure the `make_branding_pngs.py` script is not ignored and is tracked in version control.