### PR TITLE
Fix conversions trying to incorrectly access converters

### DIFF
--- a/custom_components/haeo/data/loader/extractors/utils/base_unit.py
+++ b/custom_components/haeo/data/loader/extractors/utils/base_unit.py
@@ -20,7 +20,13 @@ def base_unit_for_device_class(device_class: SensorDeviceClass | None) -> str | 
 def convert_to_base_unit(value: float, from_unit: str | None, device_class: SensorDeviceClass | None) -> float:
     """Convert *value* expressed in *from_unit* to the canonical base unit."""
     base_unit = base_unit_for_device_class(device_class)
-    if base_unit != from_unit and (converter := UNIT_CONVERTERS.get(device_class)):
+    # Only convert if we have valid from_unit, base_unit, and they differ
+    if (
+        from_unit is not None
+        and base_unit is not None
+        and base_unit != from_unit
+        and (converter := UNIT_CONVERTERS.get(device_class))
+    ):
         return converter.convert(value, from_unit, base_unit)
 
     return value

--- a/custom_components/haeo/data/loader/extractors/utils/entity_metadata.py
+++ b/custom_components/haeo/data/loader/extractors/utils/entity_metadata.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, cast
 
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 
 if TYPE_CHECKING:
     from custom_components.haeo.schema.util import UnitSpec
@@ -54,7 +55,7 @@ def extract_entity_metadata(hass: HomeAssistant) -> list[EntityMetadata]:
         try:
             # This will only work for sensor entities that return floats
             unit = extractors.extract(state).unit
-        except (ValueError, KeyError):
+        except (ValueError, KeyError, HomeAssistantError):
             unit = state.attributes.get("unit_of_measurement")
 
         entities.append(EntityMetadata(entity_id=state.entity_id, unit_of_measurement=unit))

--- a/tests/data/loader/extractors/utils/test_base_unit.py
+++ b/tests/data/loader/extractors/utils/test_base_unit.py
@@ -1,0 +1,65 @@
+"""Tests for base unit conversion utilities."""
+
+from homeassistant.components.sensor import SensorDeviceClass
+from homeassistant.const import UnitOfPower
+import pytest
+
+from custom_components.haeo.data.loader.extractors.utils.base_unit import (
+    base_unit_for_device_class,
+    convert_to_base_unit,
+)
+
+
+@pytest.mark.parametrize(
+    ("device_class", "expected"),
+    [
+        (SensorDeviceClass.POWER, "kW"),
+        (SensorDeviceClass.ENERGY, "kWh"),
+        (SensorDeviceClass.ENERGY_STORAGE, "kWh"),
+        (SensorDeviceClass.TEMPERATURE, None),
+        (SensorDeviceClass.HUMIDITY, None),
+        (SensorDeviceClass.PRESSURE, None),
+        (None, None),
+    ],
+)
+def test_base_unit_for_device_class(device_class: SensorDeviceClass | None, expected: str | None) -> None:
+    """Test base unit lookup for various device classes."""
+    assert base_unit_for_device_class(device_class) == expected
+
+
+@pytest.mark.parametrize(
+    ("value", "unit", "device_class", "expected"),
+    [
+        # Power conversions
+        (1000.0, "W", SensorDeviceClass.POWER, 1.0),
+        (1.0, "MW", SensorDeviceClass.POWER, 1000.0),
+        (1.0, UnitOfPower.WATT, SensorDeviceClass.POWER, 0.001),
+        (1.0, UnitOfPower.KILO_WATT, SensorDeviceClass.POWER, 1.0),
+        # Energy conversions
+        (1000.0, "Wh", SensorDeviceClass.ENERGY, 1.0),
+        (1.0, "MWh", SensorDeviceClass.ENERGY, 1000.0),
+        (5.0, "kWh", SensorDeviceClass.ENERGY, 5.0),
+        # Energy storage uses same base unit as energy
+        (1000.0, "Wh", SensorDeviceClass.ENERGY_STORAGE, 1.0),
+        # No conversion when already in base unit
+        (5.0, "kW", SensorDeviceClass.POWER, 5.0),
+        # No conversion for None device class
+        (100.0, "W", None, 100.0),
+        # No conversion for unsupported device classes (have HA converters but no base unit)
+        (25.0, "°C", SensorDeviceClass.TEMPERATURE, 25.0),
+        (50.0, "%", SensorDeviceClass.HUMIDITY, 50.0),
+        (75.0, "%", SensorDeviceClass.BATTERY, 75.0),
+        # No conversion for device classes without HA converters
+        (100.0, "$", SensorDeviceClass.MONETARY, 100.0),
+        # No conversion when from_unit is None
+        (100.0, None, SensorDeviceClass.POWER, 100.0),
+    ],
+)
+def test_convert_to_base_unit(
+    value: float,
+    unit: str | None,
+    device_class: SensorDeviceClass | None,
+    expected: float,
+) -> None:
+    """Test unit conversion to base units for various device classes and units."""
+    assert convert_to_base_unit(value, unit, device_class) == pytest.approx(expected)

--- a/tests/data/loader/test_sensor_loader.py
+++ b/tests/data/loader/test_sensor_loader.py
@@ -9,24 +9,7 @@ from homeassistant.core import HomeAssistant
 import pytest
 
 from custom_components.haeo.data.loader.extractors import ExtractedData
-from custom_components.haeo.data.loader.extractors.utils import convert_to_base_unit
 from custom_components.haeo.data.loader.sensor_loader import load_sensor, load_sensors, normalize_entity_ids
-
-
-@pytest.mark.parametrize(
-    ("value", "unit", "cls", "expected"),
-    [
-        (1, UnitOfPower.WATT, SensorDeviceClass.POWER, 0.001),
-        (1, UnitOfPower.KILO_WATT, SensorDeviceClass.POWER, 1),
-        (5, "kWh", SensorDeviceClass.ENERGY, 5),
-        (75, "%", SensorDeviceClass.BATTERY, 75),
-    ],
-)
-def test_convert_to_base_unit(value: float, unit: str, cls: SensorDeviceClass | str, expected: float) -> None:
-    """Ensure the helper converts as expected to kW/kWh base units."""
-
-    device_class = cls if isinstance(cls, SensorDeviceClass) else None
-    assert convert_to_base_unit(value, unit, device_class) == expected
 
 
 def test_normalize_entity_ids_accepts_str_and_sequence() -> None:


### PR DESCRIPTION
This pull request improves the reliability and test coverage of the unit conversion utilities for sensor entities. The main changes include making the `convert_to_base_unit` function more robust, expanding exception handling when extracting entity metadata, and introducing comprehensive unit tests for base unit conversion logic.

Before when trying to enumerate all sensors haeo was crashing due to it trying to convert "none" types (types that didn't have a base unit like temperature)

Now it only converts units it can convert.