### PR TITLE
Group dependabot updates to make less PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,14 @@
 # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 version: 2
 updates:
-  - package-ecosystem: "devcontainers"
-    directory: "/"
-    schedule:
-      interval: "daily"
-
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
 
   - package-ecosystem: "pip"
     directory: "/"
@@ -18,3 +17,7 @@ updates:
     ignore:
       # Dependabot should not update Home Assistant as that should match the homeassistant key in hacs.json
       - dependency-name: "homeassistant"
+    groups:
+      pip-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
This pull request updates the `.github/dependabot.yml` configuration to improve dependency management by grouping updates for both GitHub Actions and Python (pip) dependencies. The main changes are the addition of groupings for these ecosystems, which will help organize and consolidate related dependency update pull requests.