### PR TITLE
Update constant pattern to use walrus operator to reduce repetition

### DIFF
--- a/custom_components/haeo/const.py
+++ b/custom_components/haeo/const.py
@@ -17,9 +17,6 @@ CONF_DEBOUNCE_SECONDS: Final = "debounce_seconds"
 
 ELEMENT_TYPE_NETWORK: Final = "network"
 
-type NetworkDeviceName = Literal["network"]
-NETWORK_DEVICE_NETWORK: Final = "network"
-NETWORK_DEVICE_NAMES: Final[frozenset[NetworkDeviceName]] = frozenset((NETWORK_DEVICE_NETWORK,))
 
 # Horizon and period configuration
 CONF_HORIZON_HOURS: Final = "horizon_hours"
@@ -34,21 +31,21 @@ OPTIMIZATION_STATUS_SUCCESS: Final = "success"
 OPTIMIZATION_STATUS_FAILED: Final = "failed"
 OPTIMIZATION_STATUS_PENDING: Final = "pending"
 
-# Network output names
-OUTPUT_NAME_OPTIMIZATION_COST: Final = "network_optimization_cost"
-OUTPUT_NAME_OPTIMIZATION_STATUS: Final = "network_optimization_status"
-OUTPUT_NAME_OPTIMIZATION_DURATION: Final = "network_optimization_duration"
-
 type NetworkOutputName = Literal[
     "network_optimization_cost",
     "network_optimization_status",
     "network_optimization_duration",
 ]
-
 NETWORK_OUTPUT_NAMES: Final[frozenset[NetworkOutputName]] = frozenset(
     [
-        OUTPUT_NAME_OPTIMIZATION_COST,
-        OUTPUT_NAME_OPTIMIZATION_STATUS,
-        OUTPUT_NAME_OPTIMIZATION_DURATION,
+        OUTPUT_NAME_OPTIMIZATION_COST := "network_optimization_cost",
+        OUTPUT_NAME_OPTIMIZATION_STATUS := "network_optimization_status",
+        OUTPUT_NAME_OPTIMIZATION_DURATION := "network_optimization_duration",
     ]
+)
+
+type NetworkDeviceName = Literal["network"]
+
+NETWORK_DEVICE_NAMES: Final[frozenset[NetworkDeviceName]] = frozenset(
+    (NETWORK_DEVICE_NETWORK := "network",),
 )

--- a/custom_components/haeo/elements/battery.py
+++ b/custom_components/haeo/elements/battery.py
@@ -28,12 +28,6 @@ from custom_components.haeo.schema.fields import (
 
 ELEMENT_TYPE: Final = "battery"
 
-# Device names for battery devices (used for translations)
-BATTERY_DEVICE_BATTERY: Final = ELEMENT_TYPE
-BATTERY_DEVICE_UNDERCHARGE: Final = "battery_device_undercharge"
-BATTERY_DEVICE_NORMAL: Final = "battery_device_normal"
-BATTERY_DEVICE_OVERCHARGE: Final = "battery_device_overcharge"
-
 type BatteryDeviceName = Literal[
     "battery",
     "battery_device_undercharge",
@@ -43,10 +37,10 @@ type BatteryDeviceName = Literal[
 
 BATTERY_DEVICE_NAMES: Final[frozenset[BatteryDeviceName]] = frozenset(
     (
-        BATTERY_DEVICE_BATTERY,
-        BATTERY_DEVICE_UNDERCHARGE,
-        BATTERY_DEVICE_NORMAL,
-        BATTERY_DEVICE_OVERCHARGE,
+        BATTERY_DEVICE_BATTERY := ELEMENT_TYPE,
+        BATTERY_DEVICE_UNDERCHARGE := "battery_device_undercharge",
+        BATTERY_DEVICE_NORMAL := "battery_device_normal",
+        BATTERY_DEVICE_OVERCHARGE := "battery_device_overcharge",
     )
 )
 
@@ -66,20 +60,6 @@ CONF_UNDERCHARGE_COST: Final = "undercharge_cost"
 CONF_OVERCHARGE_COST: Final = "overcharge_cost"
 CONF_CONNECTION: Final = "connection"
 
-# Battery-specific sensor names (for translation/output mapping)
-BATTERY_POWER_CHARGE: Final = "battery_power_charge"
-BATTERY_POWER_DISCHARGE: Final = "battery_power_discharge"
-BATTERY_ENERGY_STORED: Final = "battery_energy_stored"
-BATTERY_STATE_OF_CHARGE: Final = "battery_state_of_charge"
-BATTERY_POWER_BALANCE: Final = "battery_power_balance"
-BATTERY_CHARGE_PRICE: Final = "battery_charge_price"
-BATTERY_DISCHARGE_PRICE: Final = "battery_discharge_price"
-BATTERY_ENERGY_IN_FLOW: Final = "battery_energy_in_flow"
-BATTERY_ENERGY_OUT_FLOW: Final = "battery_energy_out_flow"
-BATTERY_SOC_MAX: Final = "battery_soc_max"
-BATTERY_SOC_MIN: Final = "battery_soc_min"
-
-
 type BatteryOutputName = Literal[
     "battery_power_charge",
     "battery_power_discharge",
@@ -96,17 +76,17 @@ type BatteryOutputName = Literal[
 
 BATTERY_OUTPUT_NAMES: Final[frozenset[BatteryOutputName]] = frozenset(
     (
-        BATTERY_POWER_CHARGE,
-        BATTERY_POWER_DISCHARGE,
-        BATTERY_ENERGY_STORED,
-        BATTERY_STATE_OF_CHARGE,
-        BATTERY_POWER_BALANCE,
-        BATTERY_CHARGE_PRICE,
-        BATTERY_DISCHARGE_PRICE,
-        BATTERY_ENERGY_IN_FLOW,
-        BATTERY_ENERGY_OUT_FLOW,
-        BATTERY_SOC_MAX,
-        BATTERY_SOC_MIN,
+        BATTERY_POWER_CHARGE := "battery_power_charge",
+        BATTERY_POWER_DISCHARGE := "battery_power_discharge",
+        BATTERY_ENERGY_STORED := "battery_energy_stored",
+        BATTERY_STATE_OF_CHARGE := "battery_state_of_charge",
+        BATTERY_POWER_BALANCE := "battery_power_balance",
+        BATTERY_CHARGE_PRICE := "battery_charge_price",
+        BATTERY_DISCHARGE_PRICE := "battery_discharge_price",
+        BATTERY_ENERGY_IN_FLOW := "battery_energy_in_flow",
+        BATTERY_ENERGY_OUT_FLOW := "battery_energy_out_flow",
+        BATTERY_SOC_MAX := "battery_soc_max",
+        BATTERY_SOC_MIN := "battery_soc_min",
     )
 )
 

--- a/custom_components/haeo/elements/connection.py
+++ b/custom_components/haeo/elements/connection.py
@@ -81,12 +81,11 @@ CONFIG_DEFAULTS: dict[str, Any] = {}
 
 CONNECTION_OUTPUT_NAMES: Final[frozenset[ConnectionOutputName]] = MODEL_CONNECTION_OUTPUT_NAMES
 
-# Device names for connection devices (used for translations)
-CONNECTION_DEVICE_CONNECTION: Final = ELEMENT_TYPE
-
 type ConnectionDeviceName = Literal["connection"]
 
-CONNECTION_DEVICE_NAMES: Final[frozenset[ConnectionDeviceName]] = frozenset((CONNECTION_DEVICE_CONNECTION,))
+CONNECTION_DEVICE_NAMES: Final[frozenset[ConnectionDeviceName]] = frozenset(
+    (CONNECTION_DEVICE_CONNECTION := ELEMENT_TYPE,),
+)
 
 
 def create_model_elements(config: ConnectionConfigData) -> list[dict[str, Any]]:

--- a/custom_components/haeo/elements/grid.py
+++ b/custom_components/haeo/elements/grid.py
@@ -49,35 +49,26 @@ type GridOutputName = Literal[
     "grid_power_max_import_price",
     "grid_power_max_export_price",
 ]
-GRID_POWER_IMPORT: Final = "grid_power_import"
-GRID_POWER_EXPORT: Final = "grid_power_export"
-GRID_POWER_MAX_IMPORT: Final = "grid_power_max_import"
-GRID_POWER_MAX_EXPORT: Final = "grid_power_max_export"
-GRID_PRICE_IMPORT: Final = "grid_price_import"
-GRID_PRICE_EXPORT: Final = "grid_price_export"
-GRID_POWER_MAX_IMPORT_PRICE: Final = "grid_power_max_import_price"
-GRID_POWER_MAX_EXPORT_PRICE: Final = "grid_power_max_export_price"
 
 GRID_OUTPUT_NAMES: Final[frozenset[GridOutputName]] = frozenset(
     (
-        GRID_POWER_IMPORT,
-        GRID_POWER_EXPORT,
-        GRID_POWER_MAX_IMPORT,
-        GRID_POWER_MAX_EXPORT,
-        GRID_PRICE_IMPORT,
-        GRID_PRICE_EXPORT,
+        GRID_POWER_IMPORT := "grid_power_import",
+        GRID_POWER_EXPORT := "grid_power_export",
+        GRID_POWER_MAX_IMPORT := "grid_power_max_import",
+        GRID_POWER_MAX_EXPORT := "grid_power_max_export",
+        GRID_PRICE_IMPORT := "grid_price_import",
+        GRID_PRICE_EXPORT := "grid_price_export",
         # Shadow prices
-        GRID_POWER_MAX_IMPORT_PRICE,
-        GRID_POWER_MAX_EXPORT_PRICE,
+        GRID_POWER_MAX_IMPORT_PRICE := "grid_power_max_import_price",
+        GRID_POWER_MAX_EXPORT_PRICE := "grid_power_max_export_price",
     )
 )
 
-# Device names for grid devices (used for translations)
-GRID_DEVICE_GRID: Final = ELEMENT_TYPE
-
 type GridDeviceName = Literal["grid"]
 
-GRID_DEVICE_NAMES: Final[frozenset[GridDeviceName]] = frozenset((GRID_DEVICE_GRID,))
+GRID_DEVICE_NAMES: Final[frozenset[GridDeviceName]] = frozenset(
+    (GRID_DEVICE_GRID := ELEMENT_TYPE,),
+)
 
 
 class GridConfigSchema(TypedDict):

--- a/custom_components/haeo/elements/load.py
+++ b/custom_components/haeo/elements/load.py
@@ -26,11 +26,6 @@ ELEMENT_TYPE: Final = "load"
 CONF_FORECAST: Final = "forecast"
 CONF_CONNECTION: Final = "connection"
 
-# Load-specific sensor names (for translation/output mapping)
-LOAD_POWER: Final = "load_power"
-LOAD_POWER_POSSIBLE: Final = "load_power_possible"
-LOAD_FORECAST_LIMIT_PRICE: Final = "load_forecast_limit_price"
-
 type LoadOutputName = Literal[
     "load_power",
     "load_power_possible",
@@ -38,19 +33,18 @@ type LoadOutputName = Literal[
 ]
 LOAD_OUTPUT_NAMES: Final[frozenset[LoadOutputName]] = frozenset(
     (
-        LOAD_POWER,
-        LOAD_POWER_POSSIBLE,
+        LOAD_POWER := "load_power",
+        LOAD_POWER_POSSIBLE := "load_power_possible",
         # Shadow prices
-        LOAD_FORECAST_LIMIT_PRICE,
+        LOAD_FORECAST_LIMIT_PRICE := "load_forecast_limit_price",
     )
 )
 
-# Device names for load devices (used for translations)
-LOAD_DEVICE_LOAD: Final = ELEMENT_TYPE
-
 type LoadDeviceName = Literal["load"]
 
-LOAD_DEVICE_NAMES: Final[frozenset[LoadDeviceName]] = frozenset((LOAD_DEVICE_LOAD,))
+LOAD_DEVICE_NAMES: Final[frozenset[LoadDeviceName]] = frozenset(
+    (LOAD_DEVICE_LOAD := ELEMENT_TYPE,),
+)
 
 
 class LoadConfigSchema(TypedDict):

--- a/custom_components/haeo/elements/node.py
+++ b/custom_components/haeo/elements/node.py
@@ -10,19 +10,17 @@ from custom_components.haeo.schema.fields import NameFieldData, NameFieldSchema
 
 ELEMENT_TYPE: Final = "node"
 
-# Node-specific output names
-NODE_POWER_BALANCE: Final = "node_power_balance"
-
 type NodeOutputName = Literal["node_power_balance"]
 
-NODE_OUTPUT_NAMES: Final[frozenset[NodeOutputName]] = frozenset((NODE_POWER_BALANCE,))
-
-# Device names for node devices (used for translations)
-NODE_DEVICE_NODE: Final = ELEMENT_TYPE
+NODE_OUTPUT_NAMES: Final[frozenset[NodeOutputName]] = frozenset(
+    (NODE_POWER_BALANCE := "node_power_balance",),
+)
 
 type NodeDeviceName = Literal["node"]
 
-NODE_DEVICE_NAMES: Final[frozenset[NodeDeviceName]] = frozenset((NODE_DEVICE_NODE,))
+NODE_DEVICE_NAMES: Final[frozenset[NodeDeviceName]] = frozenset(
+    (NODE_DEVICE_NODE := ELEMENT_TYPE,),
+)
 
 
 class NodeConfigSchema(TypedDict):

--- a/custom_components/haeo/elements/photovoltaics.py
+++ b/custom_components/haeo/elements/photovoltaics.py
@@ -35,12 +35,6 @@ CONF_PRICE_CONSUMPTION: Final = "price_consumption"
 CONF_CURTAILMENT: Final = "curtailment"
 CONF_CONNECTION: Final = "connection"
 
-# Photovoltaics-specific sensor names (for translation/output mapping)
-PHOTOVOLTAICS_POWER: Final = "photovoltaics_power"
-PHOTOVOLTAICS_PRICE: Final = "photovoltaics_price"
-PHOTOVOLTAICS_POWER_AVAILABLE: Final = "photovoltaics_power_available"
-PHOTOVOLTAICS_FORECAST_LIMIT: Final = "photovoltaics_forecast_limit"
-
 type PhotovoltaicsOutputName = Literal[
     "photovoltaics_power",
     "photovoltaics_power_available",
@@ -51,20 +45,19 @@ type PhotovoltaicsOutputName = Literal[
 
 PHOTOVOLTAIC_OUTPUT_NAMES: Final[frozenset[PhotovoltaicsOutputName]] = frozenset(
     (
-        PHOTOVOLTAICS_POWER,
-        PHOTOVOLTAICS_POWER_AVAILABLE,
-        PHOTOVOLTAICS_PRICE,
+        PHOTOVOLTAICS_POWER := "photovoltaics_power",
+        PHOTOVOLTAICS_POWER_AVAILABLE := "photovoltaics_power_available",
+        PHOTOVOLTAICS_PRICE := "photovoltaics_price",
         # Shadow prices
-        PHOTOVOLTAICS_FORECAST_LIMIT,
+        PHOTOVOLTAICS_FORECAST_LIMIT := "photovoltaics_forecast_limit",
     )
 )
 
-# Device names for photovoltaics devices (used for translations)
-PHOTOVOLTAICS_DEVICE_PHOTOVOLTAICS: Final = ELEMENT_TYPE
-
 type PhotovoltaicsDeviceName = Literal["photovoltaics"]
 
-PHOTOVOLTAICS_DEVICE_NAMES: Final[frozenset[PhotovoltaicsDeviceName]] = frozenset((PHOTOVOLTAICS_DEVICE_PHOTOVOLTAICS,))
+PHOTOVOLTAICS_DEVICE_NAMES: Final[frozenset[PhotovoltaicsDeviceName]] = frozenset(
+    (PHOTOVOLTAICS_DEVICE_PHOTOVOLTAICS := ELEMENT_TYPE,)
+)
 
 
 class PhotovoltaicsConfigSchema(TypedDict):

--- a/custom_components/haeo/model/battery.py
+++ b/custom_components/haeo/model/battery.py
@@ -17,51 +17,11 @@ BATTERY_SECTION_UNDERCHARGE: Final = "undercharge"
 BATTERY_SECTION_NORMAL: Final = "normal"
 BATTERY_SECTION_OVERCHARGE: Final = "overcharge"
 
-# Battery constraint names (also used as shadow price output names)
-BATTERY_POWER_BALANCE: Final = "battery_power_balance"
-
 # Internal section constraint name patterns (used to build shadow price outputs)
 BATTERY_ENERGY_IN_FLOW: Final = "energy_in_flow"
 BATTERY_ENERGY_OUT_FLOW: Final = "energy_out_flow"
 BATTERY_SOC_MAX: Final = "soc_max"
 BATTERY_SOC_MIN: Final = "soc_min"
-
-# Battery output names
-BATTERY_POWER_CHARGE: Final = "battery_power_charge"
-BATTERY_POWER_DISCHARGE: Final = "battery_power_discharge"
-BATTERY_ENERGY_STORED: Final = "battery_energy_stored"
-BATTERY_STATE_OF_CHARGE: Final = "battery_state_of_charge"
-
-# Section-specific output names
-BATTERY_UNDERCHARGE_ENERGY_STORED: Final = "battery_undercharge_energy_stored"
-BATTERY_UNDERCHARGE_POWER_CHARGE: Final = "battery_undercharge_power_charge"
-BATTERY_UNDERCHARGE_POWER_DISCHARGE: Final = "battery_undercharge_power_discharge"
-BATTERY_UNDERCHARGE_CHARGE_PRICE: Final = "battery_undercharge_charge_price"
-BATTERY_UNDERCHARGE_DISCHARGE_PRICE: Final = "battery_undercharge_discharge_price"
-BATTERY_UNDERCHARGE_ENERGY_IN_FLOW: Final = "battery_undercharge_energy_in_flow"
-BATTERY_UNDERCHARGE_ENERGY_OUT_FLOW: Final = "battery_undercharge_energy_out_flow"
-BATTERY_UNDERCHARGE_SOC_MAX: Final = "battery_undercharge_soc_max"
-BATTERY_UNDERCHARGE_SOC_MIN: Final = "battery_undercharge_soc_min"
-
-BATTERY_NORMAL_ENERGY_STORED: Final = "battery_normal_energy_stored"
-BATTERY_NORMAL_POWER_CHARGE: Final = "battery_normal_power_charge"
-BATTERY_NORMAL_POWER_DISCHARGE: Final = "battery_normal_power_discharge"
-BATTERY_NORMAL_CHARGE_PRICE: Final = "battery_normal_charge_price"
-BATTERY_NORMAL_DISCHARGE_PRICE: Final = "battery_normal_discharge_price"
-BATTERY_NORMAL_ENERGY_IN_FLOW: Final = "battery_normal_energy_in_flow"
-BATTERY_NORMAL_ENERGY_OUT_FLOW: Final = "battery_normal_energy_out_flow"
-BATTERY_NORMAL_SOC_MAX: Final = "battery_normal_soc_max"
-BATTERY_NORMAL_SOC_MIN: Final = "battery_normal_soc_min"
-
-BATTERY_OVERCHARGE_ENERGY_STORED: Final = "battery_overcharge_energy_stored"
-BATTERY_OVERCHARGE_POWER_CHARGE: Final = "battery_overcharge_power_charge"
-BATTERY_OVERCHARGE_POWER_DISCHARGE: Final = "battery_overcharge_power_discharge"
-BATTERY_OVERCHARGE_CHARGE_PRICE: Final = "battery_overcharge_charge_price"
-BATTERY_OVERCHARGE_DISCHARGE_PRICE: Final = "battery_overcharge_discharge_price"
-BATTERY_OVERCHARGE_ENERGY_IN_FLOW: Final = "battery_overcharge_energy_in_flow"
-BATTERY_OVERCHARGE_ENERGY_OUT_FLOW: Final = "battery_overcharge_energy_out_flow"
-BATTERY_OVERCHARGE_SOC_MAX: Final = "battery_overcharge_soc_max"
-BATTERY_OVERCHARGE_SOC_MIN: Final = "battery_overcharge_soc_min"
 
 # Type for battery constraint names (includes all internal and external constraints)
 type BatteryConstraintName = Literal[
@@ -106,64 +66,54 @@ type BatteryOutputName = (
     | BatteryConstraintName
 )
 
+BATTERY_CONSTRAINT_NAMES: Final[frozenset[BatteryConstraintName]] = frozenset(
+    (
+        BATTERY_POWER_BALANCE := "battery_power_balance",
+        BATTERY_UNDERCHARGE_ENERGY_IN_FLOW := "battery_undercharge_energy_in_flow",
+        BATTERY_UNDERCHARGE_ENERGY_OUT_FLOW := "battery_undercharge_energy_out_flow",
+        BATTERY_UNDERCHARGE_SOC_MAX := "battery_undercharge_soc_max",
+        BATTERY_UNDERCHARGE_SOC_MIN := "battery_undercharge_soc_min",
+        BATTERY_NORMAL_ENERGY_IN_FLOW := "battery_normal_energy_in_flow",
+        BATTERY_NORMAL_ENERGY_OUT_FLOW := "battery_normal_energy_out_flow",
+        BATTERY_NORMAL_SOC_MAX := "battery_normal_soc_max",
+        BATTERY_NORMAL_SOC_MIN := "battery_normal_soc_min",
+        BATTERY_OVERCHARGE_ENERGY_IN_FLOW := "battery_overcharge_energy_in_flow",
+        BATTERY_OVERCHARGE_ENERGY_OUT_FLOW := "battery_overcharge_energy_out_flow",
+        BATTERY_OVERCHARGE_SOC_MAX := "battery_overcharge_soc_max",
+        BATTERY_OVERCHARGE_SOC_MIN := "battery_overcharge_soc_min",
+    )
+)
+
+BATTERY_POWER_CONSTRAINTS: Final[frozenset[BatteryConstraintName]] = frozenset(
+    (BATTERY_POWER_BALANCE,),
+)
+
 # Set of battery output names for runtime validation and type narrowing
 # Note: Includes dynamic constraint names built from sections, so type is inferred
 BATTERY_OUTPUT_NAMES: Final[frozenset[BatteryOutputName]] = frozenset(
     (
-        BATTERY_POWER_CHARGE,
-        BATTERY_POWER_DISCHARGE,
-        BATTERY_ENERGY_STORED,
-        BATTERY_STATE_OF_CHARGE,
-        BATTERY_UNDERCHARGE_ENERGY_STORED,
-        BATTERY_UNDERCHARGE_POWER_CHARGE,
-        BATTERY_UNDERCHARGE_POWER_DISCHARGE,
-        BATTERY_UNDERCHARGE_CHARGE_PRICE,
-        BATTERY_UNDERCHARGE_DISCHARGE_PRICE,
-        BATTERY_NORMAL_ENERGY_STORED,
-        BATTERY_NORMAL_POWER_CHARGE,
-        BATTERY_NORMAL_POWER_DISCHARGE,
-        BATTERY_NORMAL_CHARGE_PRICE,
-        BATTERY_NORMAL_DISCHARGE_PRICE,
-        BATTERY_OVERCHARGE_ENERGY_STORED,
-        BATTERY_OVERCHARGE_POWER_CHARGE,
-        BATTERY_OVERCHARGE_POWER_DISCHARGE,
-        BATTERY_OVERCHARGE_CHARGE_PRICE,
-        BATTERY_OVERCHARGE_DISCHARGE_PRICE,
-        BATTERY_POWER_BALANCE,
-        BATTERY_UNDERCHARGE_ENERGY_IN_FLOW,
-        BATTERY_UNDERCHARGE_ENERGY_OUT_FLOW,
-        BATTERY_UNDERCHARGE_SOC_MAX,
-        BATTERY_UNDERCHARGE_SOC_MIN,
-        BATTERY_NORMAL_ENERGY_IN_FLOW,
-        BATTERY_NORMAL_ENERGY_OUT_FLOW,
-        BATTERY_NORMAL_SOC_MAX,
-        BATTERY_NORMAL_SOC_MIN,
-        BATTERY_OVERCHARGE_ENERGY_IN_FLOW,
-        BATTERY_OVERCHARGE_ENERGY_OUT_FLOW,
-        BATTERY_OVERCHARGE_SOC_MAX,
-        BATTERY_OVERCHARGE_SOC_MIN,
+        BATTERY_POWER_CHARGE := "battery_power_charge",
+        BATTERY_POWER_DISCHARGE := "battery_power_discharge",
+        BATTERY_ENERGY_STORED := "battery_energy_stored",
+        BATTERY_STATE_OF_CHARGE := "battery_state_of_charge",
+        BATTERY_UNDERCHARGE_ENERGY_STORED := "battery_undercharge_energy_stored",
+        BATTERY_UNDERCHARGE_POWER_CHARGE := "battery_undercharge_power_charge",
+        BATTERY_UNDERCHARGE_POWER_DISCHARGE := "battery_undercharge_power_discharge",
+        BATTERY_UNDERCHARGE_CHARGE_PRICE := "battery_undercharge_charge_price",
+        BATTERY_UNDERCHARGE_DISCHARGE_PRICE := "battery_undercharge_discharge_price",
+        BATTERY_NORMAL_ENERGY_STORED := "battery_normal_energy_stored",
+        BATTERY_NORMAL_POWER_CHARGE := "battery_normal_power_charge",
+        BATTERY_NORMAL_POWER_DISCHARGE := "battery_normal_power_discharge",
+        BATTERY_NORMAL_CHARGE_PRICE := "battery_normal_charge_price",
+        BATTERY_NORMAL_DISCHARGE_PRICE := "battery_normal_discharge_price",
+        BATTERY_OVERCHARGE_ENERGY_STORED := "battery_overcharge_energy_stored",
+        BATTERY_OVERCHARGE_POWER_CHARGE := "battery_overcharge_power_charge",
+        BATTERY_OVERCHARGE_POWER_DISCHARGE := "battery_overcharge_power_discharge",
+        BATTERY_OVERCHARGE_CHARGE_PRICE := "battery_overcharge_charge_price",
+        BATTERY_OVERCHARGE_DISCHARGE_PRICE := "battery_overcharge_discharge_price",
+        *BATTERY_CONSTRAINT_NAMES,
     )
 )
-
-BATTERY_CONSTRAINT_NAMES: Final[frozenset[BatteryConstraintName]] = frozenset(
-    (
-        BATTERY_POWER_BALANCE,
-        BATTERY_UNDERCHARGE_ENERGY_IN_FLOW,
-        BATTERY_UNDERCHARGE_ENERGY_OUT_FLOW,
-        BATTERY_UNDERCHARGE_SOC_MAX,
-        BATTERY_UNDERCHARGE_SOC_MIN,
-        BATTERY_NORMAL_ENERGY_IN_FLOW,
-        BATTERY_NORMAL_ENERGY_OUT_FLOW,
-        BATTERY_NORMAL_SOC_MAX,
-        BATTERY_NORMAL_SOC_MIN,
-        BATTERY_OVERCHARGE_ENERGY_IN_FLOW,
-        BATTERY_OVERCHARGE_ENERGY_OUT_FLOW,
-        BATTERY_OVERCHARGE_SOC_MAX,
-        BATTERY_OVERCHARGE_SOC_MIN,
-    )
-)
-
-BATTERY_POWER_CONSTRAINTS: Final[frozenset[BatteryConstraintName]] = frozenset((BATTERY_POWER_BALANCE,))
 
 
 def _is_battery_constraint_name(name: str) -> TypeGuard[BatteryConstraintName]:

--- a/custom_components/haeo/model/connection.py
+++ b/custom_components/haeo/model/connection.py
@@ -10,17 +10,6 @@ from .element import Element
 from .output_data import OutputData
 from .util import broadcast_to_sequence
 
-CONNECTION_POWER_SOURCE_TARGET: Final = "connection_power_source_target"
-CONNECTION_POWER_TARGET_SOURCE: Final = "connection_power_target_source"
-CONNECTION_POWER_MAX_SOURCE_TARGET: Final = "connection_power_max_source_target"
-CONNECTION_POWER_MAX_TARGET_SOURCE: Final = "connection_power_max_target_source"
-CONNECTION_PRICE_SOURCE_TARGET: Final = "connection_price_source_target"
-CONNECTION_PRICE_TARGET_SOURCE: Final = "connection_price_target_source"
-
-CONNECTION_SHADOW_POWER_MAX_SOURCE_TARGET: Final = "connection_shadow_power_max_source_target"
-CONNECTION_SHADOW_POWER_MAX_TARGET_SOURCE: Final = "connection_shadow_power_max_target_source"
-CONNECTION_TIME_SLICE: Final = "connection_time_slice"
-
 type ConnectionConstraintName = Literal[
     "connection_shadow_power_max_source_target",
     "connection_shadow_power_max_target_source",
@@ -41,16 +30,16 @@ type ConnectionOutputName = (
 
 CONNECTION_OUTPUT_NAMES: Final[frozenset[ConnectionOutputName]] = frozenset(
     (
-        CONNECTION_POWER_SOURCE_TARGET,
-        CONNECTION_POWER_TARGET_SOURCE,
-        CONNECTION_POWER_MAX_SOURCE_TARGET,
-        CONNECTION_POWER_MAX_TARGET_SOURCE,
-        CONNECTION_PRICE_SOURCE_TARGET,
-        CONNECTION_PRICE_TARGET_SOURCE,
+        CONNECTION_POWER_SOURCE_TARGET := "connection_power_source_target",
+        CONNECTION_POWER_TARGET_SOURCE := "connection_power_target_source",
+        CONNECTION_POWER_MAX_SOURCE_TARGET := "connection_power_max_source_target",
+        CONNECTION_POWER_MAX_TARGET_SOURCE := "connection_power_max_target_source",
+        CONNECTION_PRICE_SOURCE_TARGET := "connection_price_source_target",
+        CONNECTION_PRICE_TARGET_SOURCE := "connection_price_target_source",
         # Constraints
-        CONNECTION_SHADOW_POWER_MAX_SOURCE_TARGET,
-        CONNECTION_SHADOW_POWER_MAX_TARGET_SOURCE,
-        CONNECTION_TIME_SLICE,
+        CONNECTION_SHADOW_POWER_MAX_SOURCE_TARGET := "connection_shadow_power_max_source_target",
+        CONNECTION_SHADOW_POWER_MAX_TARGET_SOURCE := "connection_shadow_power_max_target_source",
+        CONNECTION_TIME_SLICE := "connection_time_slice",
     )
 )
 

--- a/custom_components/haeo/model/const.py
+++ b/custom_components/haeo/model/const.py
@@ -2,18 +2,6 @@
 
 from typing import Final, Literal
 
-# Output types
-OUTPUT_TYPE_POWER: Final = "power"
-OUTPUT_TYPE_POWER_FLOW: Final = "power_flow"
-OUTPUT_TYPE_POWER_LIMIT: Final = "power_limit"
-OUTPUT_TYPE_ENERGY: Final = "energy"
-OUTPUT_TYPE_PRICE: Final = "price"
-OUTPUT_TYPE_SOC: Final = "soc"
-OUTPUT_TYPE_COST: Final = "cost"
-OUTPUT_TYPE_STATUS: Final = "status"
-OUTPUT_TYPE_DURATION: Final = "duration"
-OUTPUT_TYPE_SHADOW_PRICE: Final = "shadow_price"
-
 type OutputType = Literal[
     "power",
     "power_flow",
@@ -26,3 +14,18 @@ type OutputType = Literal[
     "duration",
     "shadow_price",
 ]
+
+OUTPUT_TYPES: Final[frozenset[OutputType]] = frozenset(
+    (
+        OUTPUT_TYPE_POWER := "power",
+        OUTPUT_TYPE_POWER_FLOW := "power_flow",
+        OUTPUT_TYPE_POWER_LIMIT := "power_limit",
+        OUTPUT_TYPE_ENERGY := "energy",
+        OUTPUT_TYPE_PRICE := "price",
+        OUTPUT_TYPE_SOC := "soc",
+        OUTPUT_TYPE_COST := "cost",
+        OUTPUT_TYPE_STATUS := "status",
+        OUTPUT_TYPE_DURATION := "duration",
+        OUTPUT_TYPE_SHADOW_PRICE := "shadow_price",
+    )
+)

--- a/custom_components/haeo/model/node.py
+++ b/custom_components/haeo/model/node.py
@@ -7,13 +7,13 @@ from .const import OUTPUT_TYPE_SHADOW_PRICE
 from .element import Element
 from .output_data import OutputData
 
-NODE_POWER_BALANCE: Final = "node_power_balance"
-
 type NodeConstraintName = Literal["node_power_balance"]
 
 type NodeOutputName = NodeConstraintName
 
-NODE_OUTPUT_NAMES: Final[frozenset[NodeOutputName]] = frozenset((NODE_POWER_BALANCE,))
+NODE_OUTPUT_NAMES: Final[frozenset[NodeOutputName]] = frozenset(
+    (NODE_POWER_BALANCE := "node_power_balance",),
+)
 
 
 class Node(Element[NodeOutputName, NodeConstraintName]):

--- a/custom_components/haeo/model/source_sink.py
+++ b/custom_components/haeo/model/source_sink.py
@@ -9,20 +9,15 @@ from .const import OUTPUT_TYPE_POWER, OUTPUT_TYPE_SHADOW_PRICE
 from .element import Element
 from .output_data import OutputData
 
-# Element-agnostic output names
-SOURCE_SINK_POWER_IN: Final = "source_sink_power_in"
-SOURCE_SINK_POWER_OUT: Final = "source_sink_power_out"
-SOURCE_SINK_POWER_BALANCE: Final = "source_sink_power_balance"
-
 type SourceSinkConstraintName = Literal["source_sink_power_balance"]
 
 type SourceSinkOutputName = Literal["source_sink_power_in", "source_sink_power_out"] | SourceSinkConstraintName
 
 SOURCE_SINK_OUTPUT_NAMES: Final[frozenset[SourceSinkOutputName]] = frozenset(
     (
-        SOURCE_SINK_POWER_IN,
-        SOURCE_SINK_POWER_OUT,
-        SOURCE_SINK_POWER_BALANCE,
+        SOURCE_SINK_POWER_IN := "source_sink_power_in",
+        SOURCE_SINK_POWER_OUT := "source_sink_power_out",
+        SOURCE_SINK_POWER_BALANCE := "source_sink_power_balance",
     )
 )
 


### PR DESCRIPTION
This pull request refactors how constant values (such as device names, output names, and constraint names) are defined and grouped throughout the codebase. Instead of defining each constant separately and then assembling them into sets, the code now uses assignment expressions directly within the set or tuple definitions. This approach reduces repetition, improves maintainability, and ensures that all relevant names are consistently available as both variables and set members.