### PR TITLE
Fix the validator to get the real data when validating

### DIFF
--- a/custom_components/haeo/const.py
+++ b/custom_components/haeo/const.py
@@ -1,6 +1,5 @@
 """Constants for the Home Assistant Energy Optimizer integration."""
 
-from collections.abc import Mapping
 from typing import Final, Literal
 
 # Integration domain
@@ -52,16 +51,6 @@ DEFAULT_DEBOUNCE_SECONDS: Final = 2  # 2 seconds debounce window
 OPTIMIZATION_STATUS_SUCCESS: Final = "success"
 OPTIMIZATION_STATUS_FAILED: Final = "failed"
 OPTIMIZATION_STATUS_PENDING: Final = "pending"
-
-
-def tiers_to_periods_seconds(config: Mapping[str, int]) -> list[int]:
-    """Convert tier configuration to list of period durations in seconds."""
-    periods: list[int] = []
-    for tier in [1, 2, 3, 4]:
-        count = config[f"tier_{tier}_count"]
-        duration_seconds = config[f"tier_{tier}_duration"] * 60  # minutes to seconds
-        periods.extend([duration_seconds] * count)
-    return periods
 
 
 type NetworkOutputName = Literal[

--- a/custom_components/haeo/data/__init__.py
+++ b/custom_components/haeo/data/__init__.py
@@ -35,7 +35,7 @@ _LOGGER = logging.getLogger(__name__)
 async def load_element_configs(
     hass: HomeAssistant,
     participants: Mapping[str, ElementConfigSchema],
-    forecast_times: Sequence[int],
+    forecast_times: Sequence[float],
 ) -> dict[str, ElementConfigData]:
     """Load sensor values for all element configurations.
 

--- a/custom_components/haeo/data/loader/extractors/__init__.py
+++ b/custom_components/haeo/data/loader/extractors/__init__.py
@@ -38,7 +38,7 @@ FORMATS: dict[ExtractorFormat, DataExtractor] = {
 class ExtractedData(NamedTuple):
     """Container for extracted data and metadata."""
 
-    data: Sequence[tuple[int, float]] | float
+    data: Sequence[tuple[float, float]] | float
     """Extracted forecast data, either a sequence of (timestamp, value) tuples or a single float value."""
     unit: str | None
     """Unit of measurement after conversion to base units. (None if unknown)"""
@@ -48,7 +48,7 @@ def extract(state: State) -> ExtractedData:
     """Extract data from a State object and convert to base units."""
 
     # Extract raw data and unit
-    data: Sequence[tuple[int, float]] | float
+    data: Sequence[tuple[float, float]] | float
     unit: str | StrEnum | None
     device_class: SensorDeviceClass | None
 

--- a/custom_components/haeo/data/loader/extractors/aemo_nem.py
+++ b/custom_components/haeo/data/loader/extractors/aemo_nem.py
@@ -63,9 +63,9 @@ class Parser:
         )
 
     @staticmethod
-    def extract(state: AemoNemState) -> tuple[Sequence[tuple[int, float]], str, SensorDeviceClass]:
+    def extract(state: AemoNemState) -> tuple[Sequence[tuple[float, float]], str, SensorDeviceClass]:
         """Extract forecast data from AEMO energy market format."""
-        parsed: list[tuple[int, float]] = [
+        parsed: list[tuple[float, float]] = [
             (parse_datetime_to_timestamp(item["start_time"]), item["price"]) for item in state.attributes["forecast"]
         ]
         parsed.sort(key=lambda x: x[0])

--- a/custom_components/haeo/data/loader/extractors/haeo.py
+++ b/custom_components/haeo/data/loader/extractors/haeo.py
@@ -88,7 +88,7 @@ class Parser:
         return device_class is None or isinstance(device_class, str)
 
     @staticmethod
-    def extract(state: HaeoForecastState) -> tuple[Sequence[tuple[int, float]], str, SensorDeviceClass | None]:
+    def extract(state: HaeoForecastState) -> tuple[Sequence[tuple[float, float]], str, SensorDeviceClass | None]:
         """Extract forecast data from HAEO forecast format.
 
         Expects list format: list of {"time": ..., "value": ...} dicts.

--- a/custom_components/haeo/data/loader/extractors/open_meteo_solar_forecast.py
+++ b/custom_components/haeo/data/loader/extractors/open_meteo_solar_forecast.py
@@ -50,9 +50,9 @@ class Parser:
         return all(is_parsable_to_datetime(k) and isinstance(v, (int, float)) for k, v in watts.items())
 
     @staticmethod
-    def extract(state: OpenMeteoSolarState) -> tuple[Sequence[tuple[int, float]], str, SensorDeviceClass]:
+    def extract(state: OpenMeteoSolarState) -> tuple[Sequence[tuple[float, float]], str, SensorDeviceClass]:
         """Extract forecast data from Open-Meteo solar forecast format."""
-        parsed: list[tuple[int, float]] = [
+        parsed: list[tuple[float, float]] = [
             (parse_datetime_to_timestamp(time), value) for time, value in state.attributes["watts"].items()
         ]
         parsed.sort(key=lambda x: x[0])

--- a/custom_components/haeo/data/loader/extractors/solcast_solar.py
+++ b/custom_components/haeo/data/loader/extractors/solcast_solar.py
@@ -67,12 +67,12 @@ class Parser:
         )
 
     @staticmethod
-    def extract(state: SolcastSolarState) -> tuple[Sequence[tuple[int, float]], str, SensorDeviceClass]:
+    def extract(state: SolcastSolarState) -> tuple[Sequence[tuple[float, float]], str, SensorDeviceClass]:
         """Extract forecast data from Solcast solar forecast format.
 
         State has been validated by detect(), so all entries are guaranteed to be valid.
         """
-        parsed: list[tuple[int, float]] = [
+        parsed: list[tuple[float, float]] = [
             (parse_datetime_to_timestamp(item["period_start"]), item["pv_estimate"])
             for item in state.attributes["detailedForecast"]
         ]

--- a/custom_components/haeo/data/loader/extractors/utils/parse_datetime.py
+++ b/custom_components/haeo/data/loader/extractors/utils/parse_datetime.py
@@ -6,14 +6,14 @@ from typing import Any
 from homeassistant.util.dt import as_utc
 
 
-def parse_datetime_to_timestamp(value: Any) -> int:
+def parse_datetime_to_timestamp(value: Any) -> float:
     """Parse a datetime string or datetime object to UTC timestamp.
 
     Args:
         value: Either a datetime object or an ISO format datetime string
 
     Returns:
-        Unix timestamp in seconds
+        Unix timestamp in seconds as a float
 
     Raises:
         ValueError: If value is not a valid datetime string or datetime object
@@ -22,12 +22,12 @@ def parse_datetime_to_timestamp(value: Any) -> int:
     # Handle datetime objects directly
     if isinstance(value, datetime):
         dt = as_utc(value)
-        return int(dt.timestamp())
+        return dt.timestamp()
 
     # Handle string datetime values
     if isinstance(value, str):
         dt = as_utc(datetime.fromisoformat(value))
-        return int(dt.timestamp())
+        return dt.timestamp()
 
     msg = f"Expected datetime or string, got {type(value).__name__}"
     raise ValueError(msg)

--- a/custom_components/haeo/data/loader/time_series_loader.py
+++ b/custom_components/haeo/data/loader/time_series_loader.py
@@ -48,7 +48,7 @@ class TimeSeriesLoader:
         *,
         hass: HomeAssistant,
         value: Any,
-        forecast_times: Sequence[int],
+        forecast_times: Sequence[float],
         **_kwargs: Any,
     ) -> list[float]:
         """Load sensor values and forecasts, returning interpolated values for ``forecast_times``.

--- a/custom_components/haeo/data/util/forecast_cycle.py
+++ b/custom_components/haeo/data/util/forecast_cycle.py
@@ -9,7 +9,7 @@ from . import ForecastSeries
 _SECONDS_PER_DAY: Final = 24 * 60 * 60
 
 
-def normalize_forecast_cycle(forecast_series: ForecastSeries, current_time: int) -> tuple[ForecastSeries, int]:
+def normalize_forecast_cycle(forecast_series: ForecastSeries, current_time: float) -> tuple[ForecastSeries, float]:
     """Return a 24-hour aligned forecast block starting at ``current_time``."""
 
     # First take the forecast and repeat it as needed to make it a multiple of 24 hours long

--- a/custom_components/haeo/data/util/forecast_fuser.py
+++ b/custom_components/haeo/data/util/forecast_fuser.py
@@ -12,7 +12,7 @@ from . import ForecastSeries
 def fuse_to_horizon(
     present_value: float | None,
     forecast_series: ForecastSeries,
-    horizon_times: Sequence[int],
+    horizon_times: Sequence[float],
 ) -> list[float]:
     """Fuse a combined forecast into interval values aligned with the requested horizon.
 

--- a/custom_components/haeo/network.py
+++ b/custom_components/haeo/network.py
@@ -22,7 +22,7 @@ async def evaluate_network_connectivity(
     """Validate the network connectivity for an entry and manage repair issues."""
 
     participants = dict(participant_configs) if participant_configs is not None else collect_participant_configs(entry)
-    result = await validate_network_topology(hass, participants)
+    result = await validate_network_topology(hass, participants, entry)
 
     if result.is_connected:
         dismiss_disconnected_network_issue(hass, entry.entry_id)

--- a/custom_components/haeo/schema/__init__.py
+++ b/custom_components/haeo/schema/__init__.py
@@ -1,5 +1,6 @@
 """Schema utilities for HAEO type configurations."""
 
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Annotated, Any, TypeVar, Union, Unpack, cast, get_args, get_origin, get_type_hints
 from typing import get_origin as typing_get_origin
 
@@ -130,16 +131,15 @@ def available(
     return True
 
 
-async def load(config: "ElementConfigSchema", hass: HomeAssistant, forecast_times: list[int]) -> "ElementConfigData":
+async def load(
+    config: "ElementConfigSchema", hass: HomeAssistant, forecast_times: Sequence[float]
+) -> "ElementConfigData":
     """Load all fields in a config, converting from Schema to Data mode.
 
     Args:
         config: Schema mode config (with entity IDs)
         hass: Home Assistant instance
-        forecast_times: Time intervals for data aggregation. When empty ([]),
-            ConstantLoader fields (strings, numbers, booleans) pass through unchanged,
-            while TimeSeriesLoader fields (sensors) return empty lists. This is useful
-            for structural validation without loading actual sensor data.
+        forecast_times: Time intervals for data aggregation.
 
     Returns:
         Data mode config (with loaded values)

--- a/custom_components/haeo/system_health.py
+++ b/custom_components/haeo/system_health.py
@@ -16,8 +16,8 @@ from .const import (
     OUTPUT_NAME_OPTIMIZATION_COST,
     OUTPUT_NAME_OPTIMIZATION_DURATION,
     OUTPUT_NAME_OPTIMIZATION_STATUS,
-    tiers_to_periods_seconds,
 )
+from .util.forecast_times import tiers_to_periods_seconds
 
 
 @callback

--- a/custom_components/haeo/util/forecast_times.py
+++ b/custom_components/haeo/util/forecast_times.py
@@ -1,0 +1,62 @@
+"""Forecast time generation utilities."""
+
+from collections.abc import Mapping, Sequence
+
+from homeassistant.util import dt as dt_util
+
+
+def tiers_to_periods_seconds(config: Mapping[str, int]) -> list[int]:
+    """Convert tier configuration to list of period durations in seconds."""
+    periods: list[int] = []
+    for tier in [1, 2, 3, 4]:
+        count = config[f"tier_{tier}_count"]
+        duration_seconds = config[f"tier_{tier}_duration"] * 60  # minutes to seconds
+        periods.extend([duration_seconds] * count)
+    return periods
+
+
+def generate_forecast_timestamps(periods_seconds: Sequence[int], start_time: float | None = None) -> tuple[float, ...]:
+    """Generate forecast timestamps as fence posts (period boundaries).
+
+    Creates n_periods+1 timestamps representing the start of each period plus
+    the end of the final period.
+
+    Args:
+        periods_seconds: Duration of each period in seconds.
+        start_time: Starting timestamp in epoch seconds. If None, uses current
+            time rounded down to the smallest period boundary.
+
+    Returns:
+        Tuple of timestamps for each fence post.
+
+    Example:
+        >>> generate_forecast_timestamps([60, 60, 300], 0.0)
+        (0.0, 60.0, 120.0, 420.0)
+
+    """
+    if start_time is None:
+        epoch_seconds = dt_util.utcnow().timestamp()
+        smallest_period = min(periods_seconds) if periods_seconds else 60
+        start_time = epoch_seconds // smallest_period * smallest_period
+
+    timestamps: list[float] = [start_time]
+    for period in periods_seconds:
+        timestamps.append(timestamps[-1] + period)
+    return tuple(timestamps)
+
+
+def generate_forecast_timestamps_from_config(config: Mapping[str, int]) -> tuple[float, ...]:
+    """Generate forecast timestamps from tier configuration.
+
+    Converts tier config to period durations and generates fence post timestamps
+    starting from the current time rounded to the smallest period boundary.
+
+    Args:
+        config: Tier configuration with tier_N_count and tier_N_duration keys.
+
+    Returns:
+        Tuple of timestamps for each fence post.
+
+    """
+    periods_seconds = tiers_to_periods_seconds(config)
+    return generate_forecast_timestamps(periods_seconds)

--- a/tests/data/loader/extractors/utils/test_parse_datetime.py
+++ b/tests/data/loader/extractors/utils/test_parse_datetime.py
@@ -10,24 +10,24 @@ from custom_components.haeo.data.loader.extractors.utils.parse_datetime import p
 def test_parse_datetime_string() -> None:
     """Test parsing ISO format datetime strings."""
     result = parse_datetime_to_timestamp("2025-10-06T00:00:00+11:00")
-    assert isinstance(result, int)
+    assert isinstance(result, float)
     # Account for the +11:00 offset (00:00 +11:00 is 13:00 UTC previous day)
-    assert result == int(datetime(2025, 10, 5, 13, 0, 0, tzinfo=UTC).timestamp())
+    assert result == datetime(2025, 10, 5, 13, 0, 0, tzinfo=UTC).timestamp()
 
 
 def test_parse_datetime_object() -> None:
     """Test parsing datetime objects directly."""
     dt = datetime(2025, 10, 6, 0, 0, 0, tzinfo=UTC)
     result = parse_datetime_to_timestamp(dt)
-    assert isinstance(result, int)
-    assert result == int(dt.timestamp())
+    assert isinstance(result, float)
+    assert result == dt.timestamp()
 
 
 def test_parse_datetime_object_no_timezone() -> None:
     """Test parsing naive datetime objects (no timezone info)."""
     dt = datetime(2025, 10, 6, 12, 30, 0, tzinfo=UTC)
     result = parse_datetime_to_timestamp(dt)
-    assert isinstance(result, int)
+    assert isinstance(result, float)
 
 
 def test_parse_invalid_string_raises_error() -> None:

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -8,7 +8,19 @@ from homeassistant.helpers import issue_registry as ir
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.haeo.const import CONF_ELEMENT_TYPE, CONF_NAME, DOMAIN
+from custom_components.haeo.const import (
+    CONF_ELEMENT_TYPE,
+    CONF_NAME,
+    CONF_TIER_1_COUNT,
+    CONF_TIER_1_DURATION,
+    CONF_TIER_2_COUNT,
+    CONF_TIER_2_DURATION,
+    CONF_TIER_3_COUNT,
+    CONF_TIER_3_DURATION,
+    CONF_TIER_4_COUNT,
+    CONF_TIER_4_DURATION,
+    DOMAIN,
+)
 from custom_components.haeo.elements import ELEMENT_TYPE_CONNECTION, ELEMENT_TYPE_NODE
 from custom_components.haeo.elements.connection import CONF_SOURCE, CONF_TARGET
 from custom_components.haeo.network import evaluate_network_connectivity
@@ -20,7 +32,17 @@ def config_entry(hass: HomeAssistant) -> MockConfigEntry:
 
     entry = MockConfigEntry(
         domain=DOMAIN,
-        data={CONF_NAME: "Test Hub"},
+        data={
+            CONF_NAME: "Test Hub",
+            CONF_TIER_1_COUNT: 2,
+            CONF_TIER_1_DURATION: 30,
+            CONF_TIER_2_COUNT: 0,
+            CONF_TIER_2_DURATION: 60,
+            CONF_TIER_3_COUNT: 0,
+            CONF_TIER_3_DURATION: 30,
+            CONF_TIER_4_COUNT: 0,
+            CONF_TIER_4_DURATION: 60,
+        },
         entry_id="test_entry",
         title="Test Hub",
     )

--- a/tests/test_network_validation.py
+++ b/tests/test_network_validation.py
@@ -1,10 +1,63 @@
 """Tests for network connectivity validation."""
 
 from homeassistant.core import HomeAssistant
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.haeo.const import CONF_ELEMENT_TYPE, CONF_NAME
+from custom_components.haeo.const import (
+    CONF_ELEMENT_TYPE,
+    CONF_INTEGRATION_TYPE,
+    CONF_NAME,
+    CONF_TIER_1_COUNT,
+    CONF_TIER_1_DURATION,
+    CONF_TIER_2_COUNT,
+    CONF_TIER_2_DURATION,
+    CONF_TIER_3_COUNT,
+    CONF_TIER_3_DURATION,
+    CONF_TIER_4_COUNT,
+    CONF_TIER_4_DURATION,
+    DOMAIN,
+    INTEGRATION_TYPE_HUB,
+)
 from custom_components.haeo.elements import ElementConfigSchema
+from custom_components.haeo.elements.battery import (
+    CONF_CAPACITY,
+    CONF_EFFICIENCY,
+    CONF_INITIAL_CHARGE_PERCENTAGE,
+    CONF_MAX_CHARGE_PERCENTAGE,
+    CONF_MIN_CHARGE_PERCENTAGE,
+    CONF_OVERCHARGE_COST,
+    CONF_OVERCHARGE_PERCENTAGE,
+    CONF_UNDERCHARGE_COST,
+    CONF_UNDERCHARGE_PERCENTAGE,
+)
+from custom_components.haeo.elements.battery import CONF_CONNECTION as BATTERY_CONF_CONNECTION
+from custom_components.haeo.elements.grid import CONF_CONNECTION as GRID_CONF_CONNECTION
+from custom_components.haeo.elements.grid import CONF_EXPORT_PRICE, CONF_IMPORT_PRICE
 from custom_components.haeo.validation import format_component_summary, validate_network_topology
+
+
+@pytest.fixture
+def mock_hub_entry(hass: HomeAssistant) -> MockConfigEntry:
+    """Create a mock hub config entry with tier configuration."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_INTEGRATION_TYPE: INTEGRATION_TYPE_HUB,
+            CONF_NAME: "Test Network",
+            CONF_TIER_1_COUNT: 2,
+            CONF_TIER_1_DURATION: 30,
+            CONF_TIER_2_COUNT: 0,
+            CONF_TIER_2_DURATION: 60,
+            CONF_TIER_3_COUNT: 0,
+            CONF_TIER_3_DURATION: 30,
+            CONF_TIER_4_COUNT: 0,
+            CONF_TIER_4_DURATION: 60,
+        },
+        entry_id="test_hub",
+    )
+    entry.add_to_hass(hass)
+    return entry
 
 
 def test_format_component_summary() -> None:
@@ -23,15 +76,33 @@ def test_format_component_summary_custom_separator() -> None:
     assert summary == "1) a, b | 2) c"
 
 
-async def test_validate_network_topology_empty(hass: HomeAssistant) -> None:
+async def test_validate_network_topology_empty(
+    hass: HomeAssistant,
+    mock_hub_entry: MockConfigEntry,
+) -> None:
     """Empty participant set is considered connected."""
-    result = await validate_network_topology(hass, {})
+    result = await validate_network_topology(hass, {}, mock_hub_entry)
     assert result.is_connected is True
     assert result.components == ()
 
 
-async def test_validate_network_topology_with_implicit_connection(hass: HomeAssistant) -> None:
+async def test_validate_network_topology_with_implicit_connection(
+    hass: HomeAssistant,
+    mock_hub_entry: MockConfigEntry,
+) -> None:
     """Element with implicit connection field creates edge to target node."""
+    # Set up mock sensors with forecast data
+    hass.states.async_set(
+        "sensor.import_price",
+        "0.30",
+        {"forecast": [{"start_time": "2025-01-01T00:00:00+00:00", "price": 0.30}]},
+    )
+    hass.states.async_set(
+        "sensor.export_price",
+        "0.10",
+        {"forecast": [{"start_time": "2025-01-01T00:00:00+00:00", "price": 0.10}]},
+    )
+
     participants: dict[str, ElementConfigSchema] = {
         "main_node": {
             CONF_ELEMENT_TYPE: "node",
@@ -40,20 +111,35 @@ async def test_validate_network_topology_with_implicit_connection(hass: HomeAssi
         "grid": {
             CONF_ELEMENT_TYPE: "grid",
             CONF_NAME: "grid",
-            "connection": "main",
-            "import_price": ["sensor.import_price"],
-            "export_price": ["sensor.export_price"],
+            GRID_CONF_CONNECTION: "main",
+            CONF_IMPORT_PRICE: ["sensor.import_price"],
+            CONF_EXPORT_PRICE: ["sensor.export_price"],
         },
     }
 
-    result = await validate_network_topology(hass, participants)
+    result = await validate_network_topology(hass, participants, mock_hub_entry)
 
     assert result.is_connected is True
     assert result.components == (("grid", "main"),)
 
 
-async def test_validate_network_topology_detects_disconnected(hass: HomeAssistant) -> None:
+async def test_validate_network_topology_detects_disconnected(
+    hass: HomeAssistant,
+    mock_hub_entry: MockConfigEntry,
+) -> None:
     """Disconnected components are properly identified."""
+    # Set up mock sensors with forecast data
+    hass.states.async_set(
+        "sensor.import_price",
+        "0.30",
+        {"forecast": [{"start_time": "2025-01-01T00:00:00+00:00", "price": 0.30}]},
+    )
+    hass.states.async_set(
+        "sensor.export_price",
+        "0.10",
+        {"forecast": [{"start_time": "2025-01-01T00:00:00+00:00", "price": 0.10}]},
+    )
+
     participants: dict[str, ElementConfigSchema] = {
         "node_a": {
             CONF_ELEMENT_TYPE: "node",
@@ -66,21 +152,131 @@ async def test_validate_network_topology_detects_disconnected(hass: HomeAssistan
         "grid_a": {
             CONF_ELEMENT_TYPE: "grid",
             CONF_NAME: "grid_a",
-            "connection": "a",
-            "import_price": ["sensor.import_price"],
-            "export_price": ["sensor.export_price"],
+            GRID_CONF_CONNECTION: "a",
+            CONF_IMPORT_PRICE: ["sensor.import_price"],
+            CONF_EXPORT_PRICE: ["sensor.export_price"],
         },
         "grid_b": {
             CONF_ELEMENT_TYPE: "grid",
             CONF_NAME: "grid_b",
-            "connection": "b",
-            "import_price": ["sensor.import_price"],
-            "export_price": ["sensor.export_price"],
+            GRID_CONF_CONNECTION: "b",
+            CONF_IMPORT_PRICE: ["sensor.import_price"],
+            CONF_EXPORT_PRICE: ["sensor.export_price"],
         },
     }
 
-    result = await validate_network_topology(hass, participants)
+    result = await validate_network_topology(hass, participants, mock_hub_entry)
 
     assert result.is_connected is False
     assert result.components == (("a", "grid_a"), ("b", "grid_b"))
     assert result.num_components == 2
+
+
+async def test_validate_network_topology_with_battery(
+    hass: HomeAssistant,
+    mock_hub_entry: MockConfigEntry,
+) -> None:
+    """Battery element works in validation with sensor data.
+
+    Regression test for https://github.com/hass-energy/haeo/issues/109.
+    Validation now loads actual sensor data with forecast_times from config entry.
+    """
+    # Set up mock sensors with present value (no forecast needed for constants)
+    hass.states.async_set(
+        "sensor.import_price",
+        "0.30",
+        {"forecast": [{"start_time": "2025-01-01T00:00:00+00:00", "price": 0.30}]},
+    )
+    hass.states.async_set(
+        "sensor.export_price",
+        "0.10",
+        {"forecast": [{"start_time": "2025-01-01T00:00:00+00:00", "price": 0.10}]},
+    )
+    hass.states.async_set("sensor.battery_capacity", "10.0")
+    hass.states.async_set("sensor.battery_soc", "50.0")
+
+    participants: dict[str, ElementConfigSchema] = {
+        "main_node": {
+            CONF_ELEMENT_TYPE: "node",
+            CONF_NAME: "main",
+        },
+        "grid": {
+            CONF_ELEMENT_TYPE: "grid",
+            CONF_NAME: "grid",
+            GRID_CONF_CONNECTION: "main",
+            CONF_IMPORT_PRICE: ["sensor.import_price"],
+            CONF_EXPORT_PRICE: ["sensor.export_price"],
+        },
+        "battery": {
+            CONF_ELEMENT_TYPE: "battery",
+            CONF_NAME: "battery",
+            BATTERY_CONF_CONNECTION: "main",
+            CONF_CAPACITY: "sensor.battery_capacity",
+            CONF_INITIAL_CHARGE_PERCENTAGE: "sensor.battery_soc",
+            CONF_MIN_CHARGE_PERCENTAGE: 10.0,
+            CONF_MAX_CHARGE_PERCENTAGE: 90.0,
+            CONF_EFFICIENCY: 95.0,
+        },
+    }
+
+    result = await validate_network_topology(hass, participants, mock_hub_entry)
+
+    assert result.is_connected is True
+    # Battery creates internal elements: battery:normal, battery:node, and connections
+    assert "battery:node" in str(result.components)
+    assert "main" in str(result.components)
+
+
+async def test_validate_network_topology_with_battery_all_sections(
+    hass: HomeAssistant,
+    mock_hub_entry: MockConfigEntry,
+) -> None:
+    """Battery with undercharge/overcharge sections works in validation.
+
+    Regression test for https://github.com/hass-energy/haeo/issues/109.
+    Tests battery configuration with all optional SOC sections.
+    """
+    # Set up mock sensors with forecast data for price fields
+    hass.states.async_set("sensor.battery_capacity", "10.0")
+    hass.states.async_set("sensor.battery_soc", "50.0")
+    hass.states.async_set(
+        "sensor.undercharge_cost",
+        "0.05",
+        {"forecast": [{"start_time": "2025-01-01T00:00:00+00:00", "price": 0.05}]},
+    )
+    hass.states.async_set(
+        "sensor.overcharge_cost",
+        "0.02",
+        {"forecast": [{"start_time": "2025-01-01T00:00:00+00:00", "price": 0.02}]},
+    )
+
+    participants: dict[str, ElementConfigSchema] = {
+        "main_node": {
+            CONF_ELEMENT_TYPE: "node",
+            CONF_NAME: "main",
+        },
+        "battery": {
+            CONF_ELEMENT_TYPE: "battery",
+            CONF_NAME: "battery",
+            BATTERY_CONF_CONNECTION: "main",
+            CONF_CAPACITY: "sensor.battery_capacity",
+            CONF_INITIAL_CHARGE_PERCENTAGE: "sensor.battery_soc",
+            CONF_MIN_CHARGE_PERCENTAGE: 10.0,
+            CONF_MAX_CHARGE_PERCENTAGE: 90.0,
+            CONF_EFFICIENCY: 95.0,
+            CONF_UNDERCHARGE_PERCENTAGE: 5.0,
+            CONF_OVERCHARGE_PERCENTAGE: 95.0,
+            CONF_UNDERCHARGE_COST: ["sensor.undercharge_cost"],
+            CONF_OVERCHARGE_COST: ["sensor.overcharge_cost"],
+        },
+    }
+
+    result = await validate_network_topology(hass, participants, mock_hub_entry)
+
+    assert result.is_connected is True
+    components_str = str(result.components)
+    # All battery sections should be present in the topology
+    assert "battery:undercharge" in components_str
+    assert "battery:normal" in components_str
+    assert "battery:overcharge" in components_str
+    assert "battery:node" in components_str

--- a/tests/util/test_forecast_times.py
+++ b/tests/util/test_forecast_times.py
@@ -1,0 +1,183 @@
+"""Tests for forecast time generation utilities."""
+
+from datetime import UTC, datetime
+from typing import TypedDict
+from unittest.mock import patch
+
+import pytest
+
+from custom_components.haeo.util.forecast_times import (
+    generate_forecast_timestamps,
+    generate_forecast_timestamps_from_config,
+    tiers_to_periods_seconds,
+)
+
+
+class TierTestCase(TypedDict):
+    """Test case for tiers_to_periods_seconds."""
+
+    description: str
+    config: dict[str, int]
+    expected: list[int]
+
+
+TIER_TEST_CASES: dict[str, TierTestCase] = {
+    "single_tier": {
+        "description": "single tier with 3 intervals of 60 seconds",
+        "config": {
+            "tier_1_count": 3,
+            "tier_1_duration": 1,  # 1 minute = 60 seconds
+            "tier_2_count": 0,
+            "tier_2_duration": 5,
+            "tier_3_count": 0,
+            "tier_3_duration": 30,
+            "tier_4_count": 0,
+            "tier_4_duration": 60,
+        },
+        "expected": [60, 60, 60],
+    },
+    "multiple_tiers": {
+        "description": "multiple tiers with different intervals",
+        "config": {
+            "tier_1_count": 2,
+            "tier_1_duration": 1,  # 60 seconds each
+            "tier_2_count": 1,
+            "tier_2_duration": 5,  # 300 seconds
+            "tier_3_count": 0,
+            "tier_3_duration": 30,
+            "tier_4_count": 0,
+            "tier_4_duration": 60,
+        },
+        "expected": [60, 60, 300],
+    },
+    "all_tiers": {
+        "description": "all four tiers populated",
+        "config": {
+            "tier_1_count": 1,
+            "tier_1_duration": 1,  # 60s
+            "tier_2_count": 1,
+            "tier_2_duration": 5,  # 300s
+            "tier_3_count": 1,
+            "tier_3_duration": 30,  # 1800s
+            "tier_4_count": 1,
+            "tier_4_duration": 60,  # 3600s
+        },
+        "expected": [60, 300, 1800, 3600],
+    },
+    "empty_tiers": {
+        "description": "all tiers with zero count",
+        "config": {
+            "tier_1_count": 0,
+            "tier_1_duration": 1,
+            "tier_2_count": 0,
+            "tier_2_duration": 5,
+            "tier_3_count": 0,
+            "tier_3_duration": 30,
+            "tier_4_count": 0,
+            "tier_4_duration": 60,
+        },
+        "expected": [],
+    },
+}
+
+
+@pytest.mark.parametrize("case_id", TIER_TEST_CASES.keys())
+def test_tiers_to_periods_seconds(case_id: str) -> None:
+    """Verify tier configuration converts to correct period durations."""
+    case = TIER_TEST_CASES[case_id]
+    result = tiers_to_periods_seconds(case["config"])
+    assert result == case["expected"], case["description"]
+
+
+class TimestampTestCase(TypedDict):
+    """Test case for generate_forecast_timestamps."""
+
+    description: str
+    periods_seconds: list[int]
+    start_time: float
+    expected: tuple[float, ...]
+
+
+TIMESTAMP_TEST_CASES: dict[str, TimestampTestCase] = {
+    "single_period": {
+        "description": "single period generates two fence posts",
+        "periods_seconds": [60],
+        "start_time": 0.0,
+        "expected": (0.0, 60.0),
+    },
+    "multiple_periods": {
+        "description": "multiple periods generate n+1 fence posts",
+        "periods_seconds": [60, 60, 300],
+        "start_time": 0.0,
+        "expected": (0.0, 60.0, 120.0, 420.0),
+    },
+    "empty_periods": {
+        "description": "empty periods generate single fence post at start",
+        "periods_seconds": [],
+        "start_time": 100.0,
+        "expected": (100.0,),
+    },
+    "nonzero_start": {
+        "description": "fence posts are relative to start time",
+        "periods_seconds": [60, 120],
+        "start_time": 1000.0,
+        "expected": (1000.0, 1060.0, 1180.0),
+    },
+    "float_start": {
+        "description": "float start time preserved",
+        "periods_seconds": [60],
+        "start_time": 1000.5,
+        "expected": (1000.5, 1060.5),
+    },
+}
+
+
+@pytest.mark.parametrize("case_id", TIMESTAMP_TEST_CASES.keys())
+def test_generate_forecast_timestamps(case_id: str) -> None:
+    """Verify forecast timestamp generation."""
+    case = TIMESTAMP_TEST_CASES[case_id]
+    result = generate_forecast_timestamps(case["periods_seconds"], case["start_time"])
+    assert result == case["expected"], case["description"]
+
+
+def test_generate_forecast_timestamps_default_start_time() -> None:
+    """Verify default start_time uses current time with rounding."""
+    periods_seconds = [60, 60]
+
+    # Mock utcnow to return a known time
+    mock_time = datetime(2025, 1, 1, 12, 0, 30, tzinfo=UTC)
+    expected_start = 1735732800.0  # 2025-01-01 12:00:00 UTC (rounded from 12:00:30)
+
+    with patch("custom_components.haeo.util.forecast_times.dt_util.utcnow", return_value=mock_time):
+        result = generate_forecast_timestamps(periods_seconds)
+
+    assert result[0] == expected_start
+    assert len(result) == 3  # 2 periods + 1 = 3 fence posts
+    assert result[1] == expected_start + 60.0
+    assert result[2] == expected_start + 120.0
+
+
+def test_generate_forecast_timestamps_from_config() -> None:
+    """Verify timestamps generated from config use proper rounding."""
+    config = {
+        "tier_1_count": 2,
+        "tier_1_duration": 1,  # 60 seconds each
+        "tier_2_count": 0,
+        "tier_2_duration": 5,
+        "tier_3_count": 0,
+        "tier_3_duration": 30,
+        "tier_4_count": 0,
+        "tier_4_duration": 60,
+    }
+
+    # Mock utcnow to return a known time
+    mock_time = datetime(2025, 1, 1, 12, 0, 30, tzinfo=UTC)
+    expected_start = 1735732800.0  # 2025-01-01 12:00:00 UTC (rounded from 12:00:30)
+
+    with patch("custom_components.haeo.util.forecast_times.dt_util.utcnow", return_value=mock_time):
+        result = generate_forecast_timestamps_from_config(config)
+
+    assert result[0] == expected_start
+    assert len(result) == 3  # 2 periods + 1 = 3 fence posts
+    assert result[1] == expected_start + 60.0
+    assert result[2] == expected_start + 120.0


### PR DESCRIPTION
The validator was passing in an empty forecast times list to get the data to validate the structure.
The battery used some of those values to initialise the state of charge.
The code then of course had an index error.

This PR updates the validator to get the full data when it tries to validate the structure so that it reflects the actual elements that are created.

Should fix #109

I also got carried away when I noticed some typing/string constant issues