### PR TITLE
Flag the inputs/outputs/visualisations to not show up in the diffs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,6 @@
 * text=auto eol=lf
+
+# Generated files - hidden by default in diffs and excluded from language statistics
+tests/scenarios/*/visualizations/*.svg linguist-generated
+tests/scenarios/*/outputs.json linguist-generated
+tests/scenarios/*/inputs.json linguist-generated


### PR DESCRIPTION
The output.json and svgs make gigantic diffs each time something updates, this git attributes will make them not count and make it much easier to review PRs