### PR TITLE
Update documentation deployment workflow to trigger on release events and fetch latest release tag

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,13 +1,8 @@
 name: Deploy Documentation
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - "docs/**"
-      - "mkdocs.yml"
-      - ".github/workflows/docs.yml"
+  release:
+    types: [published]
   workflow_dispatch:
 
 permissions:
@@ -25,9 +20,19 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Get latest release tag
+        id: latest_release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          LATEST_TAG=$(gh api repos/${{ github.repository }}/releases/latest --jq '.tag_name')
+          echo "tag=$LATEST_TAG" >> $GITHUB_OUTPUT
+          echo "Building documentation for release: $LATEST_TAG"
+
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
+          ref: ${{ steps.latest_release.outputs.tag }}
           fetch-depth: 0
 
       - name: Install uv


### PR DESCRIPTION
This pull request updates the documentation deployment workflow to trigger on new releases instead of on every push to the `main` branch or documentation files. The workflow now checks out the code at the latest release tag when building the documentation.
