### PR TITLE
Stabilise the hash so the topology images don't keep changing

### DIFF
--- a/tests/scenarios/scenario1/visualizations/scenario1_network_topology.svg
+++ b/tests/scenarios/scenario1/visualizations/scenario1_network_topology.svg
@@ -39,7 +39,7 @@ Q 238.05283 68.183267 238.05283 72.571648
 L 238.05283 221.328873 
 Q 238.05283 225.717254 242.441211 225.717254 
 z
-" clip-path="url(#pcd8c9421ca)" style="fill: #e8e8e8; opacity: 0.7; stroke: #888888; stroke-width: 1.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe60783d467)" style="fill: #e8e8e8; opacity: 0.7; stroke: #888888; stroke-width: 1.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
     <path d="M 220.905386 675.092358 
@@ -52,7 +52,7 @@ Q 216.517005 604.000588 216.517005 608.388968
 L 216.517005 670.703977 
 Q 216.517005 675.092358 220.905386 675.092358 
 z
-" clip-path="url(#pcd8c9421ca)" style="fill: #e8e8e8; opacity: 0.7; stroke: #888888; stroke-width: 1.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe60783d467)" style="fill: #e8e8e8; opacity: 0.7; stroke: #888888; stroke-width: 1.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
     <path d="M 36.825033 550.132479 
@@ -65,7 +65,7 @@ Q 32.436652 479.040709 32.436652 483.429089
 L 32.436652 545.744098 
 Q 32.436652 550.132479 36.825033 550.132479 
 z
-" clip-path="url(#pcd8c9421ca)" style="fill: #e8e8e8; opacity: 0.7; stroke: #888888; stroke-width: 1.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe60783d467)" style="fill: #e8e8e8; opacity: 0.7; stroke: #888888; stroke-width: 1.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
     <path d="M 311.034511 344.232714 
@@ -78,7 +78,7 @@ Q 306.64613 273.140944 306.64613 277.529325
 L 306.64613 339.844334 
 Q 306.64613 344.232714 311.034511 344.232714 
 z
-" clip-path="url(#pcd8c9421ca)" style="fill: #e8e8e8; opacity: 0.7; stroke: #888888; stroke-width: 1.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe60783d467)" style="fill: #e8e8e8; opacity: 0.7; stroke: #888888; stroke-width: 1.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
     <path d="M 470.466307 307.461665 
@@ -91,7 +91,7 @@ Q 466.077926 236.369894 466.077926 240.758275
 L 466.077926 303.073284 
 Q 466.077926 307.461665 470.466307 307.461665 
 z
-" clip-path="url(#pcd8c9421ca)" style="fill: #e8e8e8; opacity: 0.7; stroke: #888888; stroke-width: 1.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe60783d467)" style="fill: #e8e8e8; opacity: 0.7; stroke: #888888; stroke-width: 1.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
     <path d="M 196.244133 513.352973 
@@ -104,61 +104,61 @@ Q 191.855753 442.261203 191.855753 446.649584
 L 191.855753 508.964592 
 Q 191.855753 513.352973 196.244133 513.352973 
 z
-" clip-path="url(#pcd8c9421ca)" style="fill: #e8e8e8; opacity: 0.7; stroke: #888888; stroke-width: 1.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe60783d467)" style="fill: #e8e8e8; opacity: 0.7; stroke: #888888; stroke-width: 1.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
     <path d="M 276.350333 122.898877 
 Q 290.694595 211.965331 332.067624 290.241095 
-" clip-path="url(#pcd8c9421ca)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
+" clip-path="url(#pe60783d467)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
     <path d="M 331.916152 283.534601 
 L 332.067624 290.241095 
 L 326.611546 286.338376 
-" clip-path="url(#pcd8c9421ca)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
+" clip-path="url(#pe60783d467)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
    </g>
    <g id="patch_9">
     <path d="M 350.026798 174.473873 
 Q 323.862756 140.473011 290.812342 115.831632 
-" clip-path="url(#pcd8c9421ca)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
+" clip-path="url(#pe60783d467)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
     <path d="M 293.82938 121.823083 
 L 290.812342 115.831632 
 L 297.415726 117.012873 
-" clip-path="url(#pcd8c9421ca)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
+" clip-path="url(#pe60783d467)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
    </g>
    <g id="patch_10">
     <path d="M 252.519358 620.185925 
 Q 252.575174 556.717552 234.107843 497.750324 
-" clip-path="url(#pcd8c9421ca)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
+" clip-path="url(#pe60783d467)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
     <path d="M 233.038152 504.372693 
 L 234.107843 497.750324 
 L 238.763923 502.579498 
-" clip-path="url(#pcd8c9421ca)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
+" clip-path="url(#pe60783d467)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
    </g>
    <g id="patch_11">
     <path d="M 87.322204 513.582748 
 Q 150.613563 508.855433 208.020706 485.997073 
-" clip-path="url(#pcd8c9421ca)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
+" clip-path="url(#pe60783d467)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
     <path d="M 201.336557 485.429491 
 L 208.020706 485.997073 
 L 203.556151 491.003843 
-" clip-path="url(#pcd8c9421ca)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
+" clip-path="url(#pe60783d467)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
    </g>
    <g id="patch_12">
     <path d="M 328.632686 322.510963 
 Q 270.743842 383.708487 235.949659 458.580948 
-" clip-path="url(#pcd8c9421ca)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
+" clip-path="url(#pe60783d467)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
     <path d="M 241.198821 454.404072 
 L 235.949659 458.580948 
 L 235.757655 451.875493 
-" clip-path="url(#pcd8c9421ca)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
+" clip-path="url(#pe60783d467)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
    </g>
    <g id="patch_13">
     <path d="M 482.282838 272.918378 
 Q 418.987109 277.641704 361.574643 300.497674 
-" clip-path="url(#pcd8c9421ca)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
+" clip-path="url(#pe60783d467)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
     <path d="M 368.258753 301.065709 
 L 361.574643 300.497674 
 L 366.039537 295.491206 
-" clip-path="url(#pcd8c9421ca)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
+" clip-path="url(#pe60783d467)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
    </g>
    <g id="patch_14">
     <path d="M 259.117058 117.771971 
@@ -171,7 +171,7 @@ Q 256.922867 89.686333 256.922867 91.880524
 L 256.922867 115.577781 
 Q 256.922867 117.771971 259.117058 117.771971 
 z
-" clip-path="url(#pcd8c9421ca)" style="fill: #c7c7c7; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe60783d467)" style="fill: #c7c7c7; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
     <path d="M 341.618619 204.214188 
@@ -184,7 +184,7 @@ Q 339.424428 176.12855 339.424428 178.322741
 L 339.424428 202.019997 
 Q 339.424428 204.214188 341.618619 204.214188 
 z
-" clip-path="url(#pcd8c9421ca)" style="fill: #98df8a; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe60783d467)" style="fill: #98df8a; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
     <path d="M 225.293767 653.589292 
@@ -197,7 +197,7 @@ Q 223.099577 625.503654 223.099577 627.697844
 L 223.099577 651.395101 
 Q 223.099577 653.589292 225.293767 653.589292 
 z
-" clip-path="url(#pcd8c9421ca)" style="fill: #c7c7c7; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe60783d467)" style="fill: #c7c7c7; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
     <path d="M 53.50088 528.629413 
@@ -210,7 +210,7 @@ Q 51.30669 500.543775 51.30669 502.737965
 L 51.30669 526.435222 
 Q 51.30669 528.629413 53.50088 528.629413 
 z
-" clip-path="url(#pcd8c9421ca)" style="fill: #c7c7c7; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe60783d467)" style="fill: #c7c7c7; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
     <path d="M 324.199654 322.729648 
@@ -223,7 +223,7 @@ Q 322.005463 294.64401 322.005463 296.838201
 L 322.005463 320.535458 
 Q 322.005463 322.729648 324.199654 322.729648 
 z
-" clip-path="url(#pcd8c9421ca)" style="fill: #c7c7c7; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe60783d467)" style="fill: #c7c7c7; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
     <path d="M 487.142154 285.958598 
@@ -236,7 +236,7 @@ Q 484.947963 257.872961 484.947963 260.067151
 L 484.947963 283.764408 
 Q 484.947963 285.958598 487.142154 285.958598 
 z
-" clip-path="url(#pcd8c9421ca)" style="fill: #c7c7c7; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe60783d467)" style="fill: #c7c7c7; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
     <path d="M 204.143219 491.849907 
@@ -249,7 +249,7 @@ Q 201.949029 463.764269 201.949029 465.95846
 L 201.949029 489.655716 
 Q 201.949029 491.849907 204.143219 491.849907 
 z
-" clip-path="url(#pcd8c9421ca)" style="fill: #c7c7c7; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe60783d467)" style="fill: #c7c7c7; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- Battery -->
@@ -1661,7 +1661,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="pcd8c9421ca">
+  <clipPath id="pe60783d467">
    <rect x="7.2" y="37.837813" width="555.206348" height="667.6"/>
   </clipPath>
  </defs>

--- a/tests/scenarios/scenario2/visualizations/scenario2_network_topology.svg
+++ b/tests/scenarios/scenario2/visualizations/scenario2_network_topology.svg
@@ -39,7 +39,7 @@ Q 238.05283 68.183267 238.05283 72.571648
 L 238.05283 221.328873 
 Q 238.05283 225.717254 242.441211 225.717254 
 z
-" clip-path="url(#pcd8c9421ca)" style="fill: #e8e8e8; opacity: 0.7; stroke: #888888; stroke-width: 1.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe60783d467)" style="fill: #e8e8e8; opacity: 0.7; stroke: #888888; stroke-width: 1.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
     <path d="M 220.905386 675.092358 
@@ -52,7 +52,7 @@ Q 216.517005 604.000588 216.517005 608.388968
 L 216.517005 670.703977 
 Q 216.517005 675.092358 220.905386 675.092358 
 z
-" clip-path="url(#pcd8c9421ca)" style="fill: #e8e8e8; opacity: 0.7; stroke: #888888; stroke-width: 1.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe60783d467)" style="fill: #e8e8e8; opacity: 0.7; stroke: #888888; stroke-width: 1.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
     <path d="M 36.825033 550.132479 
@@ -65,7 +65,7 @@ Q 32.436652 479.040709 32.436652 483.429089
 L 32.436652 545.744098 
 Q 32.436652 550.132479 36.825033 550.132479 
 z
-" clip-path="url(#pcd8c9421ca)" style="fill: #e8e8e8; opacity: 0.7; stroke: #888888; stroke-width: 1.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe60783d467)" style="fill: #e8e8e8; opacity: 0.7; stroke: #888888; stroke-width: 1.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
     <path d="M 311.034511 344.232714 
@@ -78,7 +78,7 @@ Q 306.64613 273.140944 306.64613 277.529325
 L 306.64613 339.844334 
 Q 306.64613 344.232714 311.034511 344.232714 
 z
-" clip-path="url(#pcd8c9421ca)" style="fill: #e8e8e8; opacity: 0.7; stroke: #888888; stroke-width: 1.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe60783d467)" style="fill: #e8e8e8; opacity: 0.7; stroke: #888888; stroke-width: 1.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
     <path d="M 470.466307 307.461665 
@@ -91,7 +91,7 @@ Q 466.077926 236.369894 466.077926 240.758275
 L 466.077926 303.073284 
 Q 466.077926 307.461665 470.466307 307.461665 
 z
-" clip-path="url(#pcd8c9421ca)" style="fill: #e8e8e8; opacity: 0.7; stroke: #888888; stroke-width: 1.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe60783d467)" style="fill: #e8e8e8; opacity: 0.7; stroke: #888888; stroke-width: 1.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
     <path d="M 196.244133 513.352973 
@@ -104,61 +104,61 @@ Q 191.855753 442.261203 191.855753 446.649584
 L 191.855753 508.964592 
 Q 191.855753 513.352973 196.244133 513.352973 
 z
-" clip-path="url(#pcd8c9421ca)" style="fill: #e8e8e8; opacity: 0.7; stroke: #888888; stroke-width: 1.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe60783d467)" style="fill: #e8e8e8; opacity: 0.7; stroke: #888888; stroke-width: 1.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
     <path d="M 276.350333 122.898877 
 Q 290.694595 211.965331 332.067624 290.241095 
-" clip-path="url(#pcd8c9421ca)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
+" clip-path="url(#pe60783d467)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
     <path d="M 331.916152 283.534601 
 L 332.067624 290.241095 
 L 326.611546 286.338376 
-" clip-path="url(#pcd8c9421ca)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
+" clip-path="url(#pe60783d467)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
    </g>
    <g id="patch_9">
     <path d="M 350.026798 174.473873 
 Q 323.862756 140.473011 290.812342 115.831632 
-" clip-path="url(#pcd8c9421ca)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
+" clip-path="url(#pe60783d467)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
     <path d="M 293.82938 121.823083 
 L 290.812342 115.831632 
 L 297.415726 117.012873 
-" clip-path="url(#pcd8c9421ca)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
+" clip-path="url(#pe60783d467)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
    </g>
    <g id="patch_10">
     <path d="M 252.519358 620.185925 
 Q 252.575174 556.717552 234.107843 497.750324 
-" clip-path="url(#pcd8c9421ca)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
+" clip-path="url(#pe60783d467)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
     <path d="M 233.038152 504.372693 
 L 234.107843 497.750324 
 L 238.763923 502.579498 
-" clip-path="url(#pcd8c9421ca)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
+" clip-path="url(#pe60783d467)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
    </g>
    <g id="patch_11">
     <path d="M 87.322204 513.582748 
 Q 150.613563 508.855433 208.020706 485.997073 
-" clip-path="url(#pcd8c9421ca)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
+" clip-path="url(#pe60783d467)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
     <path d="M 201.336557 485.429491 
 L 208.020706 485.997073 
 L 203.556151 491.003843 
-" clip-path="url(#pcd8c9421ca)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
+" clip-path="url(#pe60783d467)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
    </g>
    <g id="patch_12">
     <path d="M 328.632686 322.510963 
 Q 270.743842 383.708487 235.949659 458.580948 
-" clip-path="url(#pcd8c9421ca)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
+" clip-path="url(#pe60783d467)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
     <path d="M 241.198821 454.404072 
 L 235.949659 458.580948 
 L 235.757655 451.875493 
-" clip-path="url(#pcd8c9421ca)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
+" clip-path="url(#pe60783d467)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
    </g>
    <g id="patch_13">
     <path d="M 482.282838 272.918378 
 Q 418.987109 277.641704 361.574643 300.497674 
-" clip-path="url(#pcd8c9421ca)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
+" clip-path="url(#pe60783d467)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
     <path d="M 368.258753 301.065709 
 L 361.574643 300.497674 
 L 366.039537 295.491206 
-" clip-path="url(#pcd8c9421ca)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
+" clip-path="url(#pe60783d467)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
    </g>
    <g id="patch_14">
     <path d="M 259.117058 117.771971 
@@ -171,7 +171,7 @@ Q 256.922867 89.686333 256.922867 91.880524
 L 256.922867 115.577781 
 Q 256.922867 117.771971 259.117058 117.771971 
 z
-" clip-path="url(#pcd8c9421ca)" style="fill: #c7c7c7; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe60783d467)" style="fill: #c7c7c7; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
     <path d="M 341.618619 204.214188 
@@ -184,7 +184,7 @@ Q 339.424428 176.12855 339.424428 178.322741
 L 339.424428 202.019997 
 Q 339.424428 204.214188 341.618619 204.214188 
 z
-" clip-path="url(#pcd8c9421ca)" style="fill: #98df8a; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe60783d467)" style="fill: #98df8a; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
     <path d="M 225.293767 653.589292 
@@ -197,7 +197,7 @@ Q 223.099577 625.503654 223.099577 627.697844
 L 223.099577 651.395101 
 Q 223.099577 653.589292 225.293767 653.589292 
 z
-" clip-path="url(#pcd8c9421ca)" style="fill: #c7c7c7; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe60783d467)" style="fill: #c7c7c7; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
     <path d="M 53.50088 528.629413 
@@ -210,7 +210,7 @@ Q 51.30669 500.543775 51.30669 502.737965
 L 51.30669 526.435222 
 Q 51.30669 528.629413 53.50088 528.629413 
 z
-" clip-path="url(#pcd8c9421ca)" style="fill: #c7c7c7; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe60783d467)" style="fill: #c7c7c7; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
     <path d="M 324.199654 322.729648 
@@ -223,7 +223,7 @@ Q 322.005463 294.64401 322.005463 296.838201
 L 322.005463 320.535458 
 Q 322.005463 322.729648 324.199654 322.729648 
 z
-" clip-path="url(#pcd8c9421ca)" style="fill: #c7c7c7; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe60783d467)" style="fill: #c7c7c7; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
     <path d="M 487.142154 285.958598 
@@ -236,7 +236,7 @@ Q 484.947963 257.872961 484.947963 260.067151
 L 484.947963 283.764408 
 Q 484.947963 285.958598 487.142154 285.958598 
 z
-" clip-path="url(#pcd8c9421ca)" style="fill: #c7c7c7; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe60783d467)" style="fill: #c7c7c7; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
     <path d="M 204.143219 491.849907 
@@ -249,7 +249,7 @@ Q 201.949029 463.764269 201.949029 465.95846
 L 201.949029 489.655716 
 Q 201.949029 491.849907 204.143219 491.849907 
 z
-" clip-path="url(#pcd8c9421ca)" style="fill: #c7c7c7; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe60783d467)" style="fill: #c7c7c7; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- Battery -->
@@ -1671,7 +1671,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="pcd8c9421ca">
+  <clipPath id="pe60783d467">
    <rect x="7.2" y="37.837813" width="555.206348" height="667.6"/>
   </clipPath>
  </defs>

--- a/tests/scenarios/scenario3/visualizations/scenario3_network_topology.svg
+++ b/tests/scenarios/scenario3/visualizations/scenario3_network_topology.svg
@@ -39,7 +39,7 @@ Q 238.05283 68.183267 238.05283 72.571648
 L 238.05283 221.328873 
 Q 238.05283 225.717254 242.441211 225.717254 
 z
-" clip-path="url(#pcd8c9421ca)" style="fill: #e8e8e8; opacity: 0.7; stroke: #888888; stroke-width: 1.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe60783d467)" style="fill: #e8e8e8; opacity: 0.7; stroke: #888888; stroke-width: 1.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
     <path d="M 220.905386 675.092358 
@@ -52,7 +52,7 @@ Q 216.517005 604.000588 216.517005 608.388968
 L 216.517005 670.703977 
 Q 216.517005 675.092358 220.905386 675.092358 
 z
-" clip-path="url(#pcd8c9421ca)" style="fill: #e8e8e8; opacity: 0.7; stroke: #888888; stroke-width: 1.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe60783d467)" style="fill: #e8e8e8; opacity: 0.7; stroke: #888888; stroke-width: 1.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
     <path d="M 36.825033 550.132479 
@@ -65,7 +65,7 @@ Q 32.436652 479.040709 32.436652 483.429089
 L 32.436652 545.744098 
 Q 32.436652 550.132479 36.825033 550.132479 
 z
-" clip-path="url(#pcd8c9421ca)" style="fill: #e8e8e8; opacity: 0.7; stroke: #888888; stroke-width: 1.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe60783d467)" style="fill: #e8e8e8; opacity: 0.7; stroke: #888888; stroke-width: 1.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
     <path d="M 311.034511 344.232714 
@@ -78,7 +78,7 @@ Q 306.64613 273.140944 306.64613 277.529325
 L 306.64613 339.844334 
 Q 306.64613 344.232714 311.034511 344.232714 
 z
-" clip-path="url(#pcd8c9421ca)" style="fill: #e8e8e8; opacity: 0.7; stroke: #888888; stroke-width: 1.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe60783d467)" style="fill: #e8e8e8; opacity: 0.7; stroke: #888888; stroke-width: 1.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
     <path d="M 470.466307 307.461665 
@@ -91,7 +91,7 @@ Q 466.077926 236.369894 466.077926 240.758275
 L 466.077926 303.073284 
 Q 466.077926 307.461665 470.466307 307.461665 
 z
-" clip-path="url(#pcd8c9421ca)" style="fill: #e8e8e8; opacity: 0.7; stroke: #888888; stroke-width: 1.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe60783d467)" style="fill: #e8e8e8; opacity: 0.7; stroke: #888888; stroke-width: 1.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
     <path d="M 196.244133 513.352973 
@@ -104,61 +104,61 @@ Q 191.855753 442.261203 191.855753 446.649584
 L 191.855753 508.964592 
 Q 191.855753 513.352973 196.244133 513.352973 
 z
-" clip-path="url(#pcd8c9421ca)" style="fill: #e8e8e8; opacity: 0.7; stroke: #888888; stroke-width: 1.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe60783d467)" style="fill: #e8e8e8; opacity: 0.7; stroke: #888888; stroke-width: 1.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
     <path d="M 276.350333 122.898877 
 Q 290.694595 211.965331 332.067624 290.241095 
-" clip-path="url(#pcd8c9421ca)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
+" clip-path="url(#pe60783d467)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
     <path d="M 331.916152 283.534601 
 L 332.067624 290.241095 
 L 326.611546 286.338376 
-" clip-path="url(#pcd8c9421ca)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
+" clip-path="url(#pe60783d467)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
    </g>
    <g id="patch_9">
     <path d="M 350.026798 174.473873 
 Q 323.862756 140.473011 290.812342 115.831632 
-" clip-path="url(#pcd8c9421ca)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
+" clip-path="url(#pe60783d467)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
     <path d="M 293.82938 121.823083 
 L 290.812342 115.831632 
 L 297.415726 117.012873 
-" clip-path="url(#pcd8c9421ca)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
+" clip-path="url(#pe60783d467)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
    </g>
    <g id="patch_10">
     <path d="M 252.519358 620.185925 
 Q 252.575174 556.717552 234.107843 497.750324 
-" clip-path="url(#pcd8c9421ca)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
+" clip-path="url(#pe60783d467)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
     <path d="M 233.038152 504.372693 
 L 234.107843 497.750324 
 L 238.763923 502.579498 
-" clip-path="url(#pcd8c9421ca)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
+" clip-path="url(#pe60783d467)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
    </g>
    <g id="patch_11">
     <path d="M 87.322204 513.582748 
 Q 150.613563 508.855433 208.020706 485.997073 
-" clip-path="url(#pcd8c9421ca)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
+" clip-path="url(#pe60783d467)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
     <path d="M 201.336557 485.429491 
 L 208.020706 485.997073 
 L 203.556151 491.003843 
-" clip-path="url(#pcd8c9421ca)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
+" clip-path="url(#pe60783d467)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
    </g>
    <g id="patch_12">
     <path d="M 328.632686 322.510963 
 Q 270.743842 383.708487 235.949659 458.580948 
-" clip-path="url(#pcd8c9421ca)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
+" clip-path="url(#pe60783d467)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
     <path d="M 241.198821 454.404072 
 L 235.949659 458.580948 
 L 235.757655 451.875493 
-" clip-path="url(#pcd8c9421ca)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
+" clip-path="url(#pe60783d467)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
    </g>
    <g id="patch_13">
     <path d="M 482.282838 272.918378 
 Q 418.987109 277.641704 361.574643 300.497674 
-" clip-path="url(#pcd8c9421ca)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
+" clip-path="url(#pe60783d467)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
     <path d="M 368.258753 301.065709 
 L 361.574643 300.497674 
 L 366.039537 295.491206 
-" clip-path="url(#pcd8c9421ca)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
+" clip-path="url(#pe60783d467)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
    </g>
    <g id="patch_14">
     <path d="M 259.117058 117.771971 
@@ -171,7 +171,7 @@ Q 256.922867 89.686333 256.922867 91.880524
 L 256.922867 115.577781 
 Q 256.922867 117.771971 259.117058 117.771971 
 z
-" clip-path="url(#pcd8c9421ca)" style="fill: #c7c7c7; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe60783d467)" style="fill: #c7c7c7; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
     <path d="M 341.618619 204.214188 
@@ -184,7 +184,7 @@ Q 339.424428 176.12855 339.424428 178.322741
 L 339.424428 202.019997 
 Q 339.424428 204.214188 341.618619 204.214188 
 z
-" clip-path="url(#pcd8c9421ca)" style="fill: #98df8a; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe60783d467)" style="fill: #98df8a; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
     <path d="M 225.293767 653.589292 
@@ -197,7 +197,7 @@ Q 223.099577 625.503654 223.099577 627.697844
 L 223.099577 651.395101 
 Q 223.099577 653.589292 225.293767 653.589292 
 z
-" clip-path="url(#pcd8c9421ca)" style="fill: #c7c7c7; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe60783d467)" style="fill: #c7c7c7; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
     <path d="M 53.50088 528.629413 
@@ -210,7 +210,7 @@ Q 51.30669 500.543775 51.30669 502.737965
 L 51.30669 526.435222 
 Q 51.30669 528.629413 53.50088 528.629413 
 z
-" clip-path="url(#pcd8c9421ca)" style="fill: #c7c7c7; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe60783d467)" style="fill: #c7c7c7; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
     <path d="M 324.199654 322.729648 
@@ -223,7 +223,7 @@ Q 322.005463 294.64401 322.005463 296.838201
 L 322.005463 320.535458 
 Q 322.005463 322.729648 324.199654 322.729648 
 z
-" clip-path="url(#pcd8c9421ca)" style="fill: #c7c7c7; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe60783d467)" style="fill: #c7c7c7; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
     <path d="M 487.142154 285.958598 
@@ -236,7 +236,7 @@ Q 484.947963 257.872961 484.947963 260.067151
 L 484.947963 283.764408 
 Q 484.947963 285.958598 487.142154 285.958598 
 z
-" clip-path="url(#pcd8c9421ca)" style="fill: #c7c7c7; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe60783d467)" style="fill: #c7c7c7; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
     <path d="M 204.143219 491.849907 
@@ -249,7 +249,7 @@ Q 201.949029 463.764269 201.949029 465.95846
 L 201.949029 489.655716 
 Q 201.949029 491.849907 204.143219 491.849907 
 z
-" clip-path="url(#pcd8c9421ca)" style="fill: #c7c7c7; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe60783d467)" style="fill: #c7c7c7; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- Battery -->
@@ -1679,7 +1679,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="pcd8c9421ca">
+  <clipPath id="pe60783d467">
    <rect x="7.2" y="37.837813" width="555.206348" height="667.6"/>
   </clipPath>
  </defs>

--- a/tests/scenarios/scenario4/visualizations/scenario4_network_topology.svg
+++ b/tests/scenarios/scenario4/visualizations/scenario4_network_topology.svg
@@ -39,7 +39,7 @@ Q 238.05283 68.183267 238.05283 72.571648
 L 238.05283 221.328873 
 Q 238.05283 225.717254 242.441211 225.717254 
 z
-" clip-path="url(#pcd8c9421ca)" style="fill: #e8e8e8; opacity: 0.7; stroke: #888888; stroke-width: 1.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe60783d467)" style="fill: #e8e8e8; opacity: 0.7; stroke: #888888; stroke-width: 1.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
     <path d="M 220.905386 675.092358 
@@ -52,7 +52,7 @@ Q 216.517005 604.000588 216.517005 608.388968
 L 216.517005 670.703977 
 Q 216.517005 675.092358 220.905386 675.092358 
 z
-" clip-path="url(#pcd8c9421ca)" style="fill: #e8e8e8; opacity: 0.7; stroke: #888888; stroke-width: 1.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe60783d467)" style="fill: #e8e8e8; opacity: 0.7; stroke: #888888; stroke-width: 1.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
     <path d="M 36.825033 550.132479 
@@ -65,7 +65,7 @@ Q 32.436652 479.040709 32.436652 483.429089
 L 32.436652 545.744098 
 Q 32.436652 550.132479 36.825033 550.132479 
 z
-" clip-path="url(#pcd8c9421ca)" style="fill: #e8e8e8; opacity: 0.7; stroke: #888888; stroke-width: 1.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe60783d467)" style="fill: #e8e8e8; opacity: 0.7; stroke: #888888; stroke-width: 1.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
     <path d="M 311.034511 344.232714 
@@ -78,7 +78,7 @@ Q 306.64613 273.140944 306.64613 277.529325
 L 306.64613 339.844334 
 Q 306.64613 344.232714 311.034511 344.232714 
 z
-" clip-path="url(#pcd8c9421ca)" style="fill: #e8e8e8; opacity: 0.7; stroke: #888888; stroke-width: 1.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe60783d467)" style="fill: #e8e8e8; opacity: 0.7; stroke: #888888; stroke-width: 1.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
     <path d="M 470.466307 307.461665 
@@ -91,7 +91,7 @@ Q 466.077926 236.369894 466.077926 240.758275
 L 466.077926 303.073284 
 Q 466.077926 307.461665 470.466307 307.461665 
 z
-" clip-path="url(#pcd8c9421ca)" style="fill: #e8e8e8; opacity: 0.7; stroke: #888888; stroke-width: 1.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe60783d467)" style="fill: #e8e8e8; opacity: 0.7; stroke: #888888; stroke-width: 1.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
     <path d="M 196.244133 513.352973 
@@ -104,61 +104,61 @@ Q 191.855753 442.261203 191.855753 446.649584
 L 191.855753 508.964592 
 Q 191.855753 513.352973 196.244133 513.352973 
 z
-" clip-path="url(#pcd8c9421ca)" style="fill: #e8e8e8; opacity: 0.7; stroke: #888888; stroke-width: 1.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe60783d467)" style="fill: #e8e8e8; opacity: 0.7; stroke: #888888; stroke-width: 1.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
     <path d="M 276.350333 122.898877 
 Q 290.694595 211.965331 332.067624 290.241095 
-" clip-path="url(#pcd8c9421ca)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
+" clip-path="url(#pe60783d467)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
     <path d="M 331.916152 283.534601 
 L 332.067624 290.241095 
 L 326.611546 286.338376 
-" clip-path="url(#pcd8c9421ca)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
+" clip-path="url(#pe60783d467)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
    </g>
    <g id="patch_9">
     <path d="M 350.026798 174.473873 
 Q 323.862756 140.473011 290.812342 115.831632 
-" clip-path="url(#pcd8c9421ca)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
+" clip-path="url(#pe60783d467)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
     <path d="M 293.82938 121.823083 
 L 290.812342 115.831632 
 L 297.415726 117.012873 
-" clip-path="url(#pcd8c9421ca)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
+" clip-path="url(#pe60783d467)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
    </g>
    <g id="patch_10">
     <path d="M 252.519358 620.185925 
 Q 252.575174 556.717552 234.107843 497.750324 
-" clip-path="url(#pcd8c9421ca)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
+" clip-path="url(#pe60783d467)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
     <path d="M 233.038152 504.372693 
 L 234.107843 497.750324 
 L 238.763923 502.579498 
-" clip-path="url(#pcd8c9421ca)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
+" clip-path="url(#pe60783d467)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
    </g>
    <g id="patch_11">
     <path d="M 87.322204 513.582748 
 Q 150.613563 508.855433 208.020706 485.997073 
-" clip-path="url(#pcd8c9421ca)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
+" clip-path="url(#pe60783d467)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
     <path d="M 201.336557 485.429491 
 L 208.020706 485.997073 
 L 203.556151 491.003843 
-" clip-path="url(#pcd8c9421ca)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
+" clip-path="url(#pe60783d467)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
    </g>
    <g id="patch_12">
     <path d="M 328.632686 322.510963 
 Q 270.743842 383.708487 235.949659 458.580948 
-" clip-path="url(#pcd8c9421ca)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
+" clip-path="url(#pe60783d467)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
     <path d="M 241.198821 454.404072 
 L 235.949659 458.580948 
 L 235.757655 451.875493 
-" clip-path="url(#pcd8c9421ca)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
+" clip-path="url(#pe60783d467)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
    </g>
    <g id="patch_13">
     <path d="M 482.282838 272.918378 
 Q 418.987109 277.641704 361.574643 300.497674 
-" clip-path="url(#pcd8c9421ca)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
+" clip-path="url(#pe60783d467)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
     <path d="M 368.258753 301.065709 
 L 361.574643 300.497674 
 L 366.039537 295.491206 
-" clip-path="url(#pcd8c9421ca)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
+" clip-path="url(#pe60783d467)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
    </g>
    <g id="patch_14">
     <path d="M 259.117058 117.771971 
@@ -171,7 +171,7 @@ Q 256.922867 89.686333 256.922867 91.880524
 L 256.922867 115.577781 
 Q 256.922867 117.771971 259.117058 117.771971 
 z
-" clip-path="url(#pcd8c9421ca)" style="fill: #c7c7c7; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe60783d467)" style="fill: #c7c7c7; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
     <path d="M 341.618619 204.214188 
@@ -184,7 +184,7 @@ Q 339.424428 176.12855 339.424428 178.322741
 L 339.424428 202.019997 
 Q 339.424428 204.214188 341.618619 204.214188 
 z
-" clip-path="url(#pcd8c9421ca)" style="fill: #98df8a; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe60783d467)" style="fill: #98df8a; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
     <path d="M 225.293767 653.589292 
@@ -197,7 +197,7 @@ Q 223.099577 625.503654 223.099577 627.697844
 L 223.099577 651.395101 
 Q 223.099577 653.589292 225.293767 653.589292 
 z
-" clip-path="url(#pcd8c9421ca)" style="fill: #c7c7c7; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe60783d467)" style="fill: #c7c7c7; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
     <path d="M 53.50088 528.629413 
@@ -210,7 +210,7 @@ Q 51.30669 500.543775 51.30669 502.737965
 L 51.30669 526.435222 
 Q 51.30669 528.629413 53.50088 528.629413 
 z
-" clip-path="url(#pcd8c9421ca)" style="fill: #c7c7c7; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe60783d467)" style="fill: #c7c7c7; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
     <path d="M 324.199654 322.729648 
@@ -223,7 +223,7 @@ Q 322.005463 294.64401 322.005463 296.838201
 L 322.005463 320.535458 
 Q 322.005463 322.729648 324.199654 322.729648 
 z
-" clip-path="url(#pcd8c9421ca)" style="fill: #c7c7c7; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe60783d467)" style="fill: #c7c7c7; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
     <path d="M 487.142154 285.958598 
@@ -236,7 +236,7 @@ Q 484.947963 257.872961 484.947963 260.067151
 L 484.947963 283.764408 
 Q 484.947963 285.958598 487.142154 285.958598 
 z
-" clip-path="url(#pcd8c9421ca)" style="fill: #c7c7c7; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe60783d467)" style="fill: #c7c7c7; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
     <path d="M 204.143219 491.849907 
@@ -249,7 +249,7 @@ Q 201.949029 463.764269 201.949029 465.95846
 L 201.949029 489.655716 
 Q 201.949029 491.849907 204.143219 491.849907 
 z
-" clip-path="url(#pcd8c9421ca)" style="fill: #c7c7c7; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe60783d467)" style="fill: #c7c7c7; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- Battery -->
@@ -1666,7 +1666,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="pcd8c9421ca">
+  <clipPath id="pe60783d467">
    <rect x="7.2" y="37.837813" width="555.206348" height="667.6"/>
   </clipPath>
  </defs>

--- a/tests/scenarios/scenario5/visualizations/scenario5_network_topology.svg
+++ b/tests/scenarios/scenario5/visualizations/scenario5_network_topology.svg
@@ -39,7 +39,7 @@ Q 238.05283 68.183267 238.05283 72.571648
 L 238.05283 221.328873 
 Q 238.05283 225.717254 242.441211 225.717254 
 z
-" clip-path="url(#pcd8c9421ca)" style="fill: #e8e8e8; opacity: 0.7; stroke: #888888; stroke-width: 1.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe60783d467)" style="fill: #e8e8e8; opacity: 0.7; stroke: #888888; stroke-width: 1.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
     <path d="M 220.905386 675.092358 
@@ -52,7 +52,7 @@ Q 216.517005 604.000588 216.517005 608.388968
 L 216.517005 670.703977 
 Q 216.517005 675.092358 220.905386 675.092358 
 z
-" clip-path="url(#pcd8c9421ca)" style="fill: #e8e8e8; opacity: 0.7; stroke: #888888; stroke-width: 1.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe60783d467)" style="fill: #e8e8e8; opacity: 0.7; stroke: #888888; stroke-width: 1.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
     <path d="M 36.825033 550.132479 
@@ -65,7 +65,7 @@ Q 32.436652 479.040709 32.436652 483.429089
 L 32.436652 545.744098 
 Q 32.436652 550.132479 36.825033 550.132479 
 z
-" clip-path="url(#pcd8c9421ca)" style="fill: #e8e8e8; opacity: 0.7; stroke: #888888; stroke-width: 1.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe60783d467)" style="fill: #e8e8e8; opacity: 0.7; stroke: #888888; stroke-width: 1.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
     <path d="M 311.034511 344.232714 
@@ -78,7 +78,7 @@ Q 306.64613 273.140944 306.64613 277.529325
 L 306.64613 339.844334 
 Q 306.64613 344.232714 311.034511 344.232714 
 z
-" clip-path="url(#pcd8c9421ca)" style="fill: #e8e8e8; opacity: 0.7; stroke: #888888; stroke-width: 1.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe60783d467)" style="fill: #e8e8e8; opacity: 0.7; stroke: #888888; stroke-width: 1.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
     <path d="M 470.466307 307.461665 
@@ -91,7 +91,7 @@ Q 466.077926 236.369894 466.077926 240.758275
 L 466.077926 303.073284 
 Q 466.077926 307.461665 470.466307 307.461665 
 z
-" clip-path="url(#pcd8c9421ca)" style="fill: #e8e8e8; opacity: 0.7; stroke: #888888; stroke-width: 1.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe60783d467)" style="fill: #e8e8e8; opacity: 0.7; stroke: #888888; stroke-width: 1.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
     <path d="M 196.244133 513.352973 
@@ -104,61 +104,61 @@ Q 191.855753 442.261203 191.855753 446.649584
 L 191.855753 508.964592 
 Q 191.855753 513.352973 196.244133 513.352973 
 z
-" clip-path="url(#pcd8c9421ca)" style="fill: #e8e8e8; opacity: 0.7; stroke: #888888; stroke-width: 1.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe60783d467)" style="fill: #e8e8e8; opacity: 0.7; stroke: #888888; stroke-width: 1.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
     <path d="M 276.350333 122.898877 
 Q 290.694595 211.965331 332.067624 290.241095 
-" clip-path="url(#pcd8c9421ca)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
+" clip-path="url(#pe60783d467)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
     <path d="M 331.916152 283.534601 
 L 332.067624 290.241095 
 L 326.611546 286.338376 
-" clip-path="url(#pcd8c9421ca)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
+" clip-path="url(#pe60783d467)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
    </g>
    <g id="patch_9">
     <path d="M 350.026798 174.473873 
 Q 323.862756 140.473011 290.812342 115.831632 
-" clip-path="url(#pcd8c9421ca)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
+" clip-path="url(#pe60783d467)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
     <path d="M 293.82938 121.823083 
 L 290.812342 115.831632 
 L 297.415726 117.012873 
-" clip-path="url(#pcd8c9421ca)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
+" clip-path="url(#pe60783d467)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
    </g>
    <g id="patch_10">
     <path d="M 252.519358 620.185925 
 Q 252.575174 556.717552 234.107843 497.750324 
-" clip-path="url(#pcd8c9421ca)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
+" clip-path="url(#pe60783d467)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
     <path d="M 233.038152 504.372693 
 L 234.107843 497.750324 
 L 238.763923 502.579498 
-" clip-path="url(#pcd8c9421ca)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
+" clip-path="url(#pe60783d467)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
    </g>
    <g id="patch_11">
     <path d="M 87.322204 513.582748 
 Q 150.613563 508.855433 208.020706 485.997073 
-" clip-path="url(#pcd8c9421ca)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
+" clip-path="url(#pe60783d467)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
     <path d="M 201.336557 485.429491 
 L 208.020706 485.997073 
 L 203.556151 491.003843 
-" clip-path="url(#pcd8c9421ca)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
+" clip-path="url(#pe60783d467)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
    </g>
    <g id="patch_12">
     <path d="M 328.632686 322.510963 
 Q 270.743842 383.708487 235.949659 458.580948 
-" clip-path="url(#pcd8c9421ca)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
+" clip-path="url(#pe60783d467)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
     <path d="M 241.198821 454.404072 
 L 235.949659 458.580948 
 L 235.757655 451.875493 
-" clip-path="url(#pcd8c9421ca)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
+" clip-path="url(#pe60783d467)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
    </g>
    <g id="patch_13">
     <path d="M 482.282838 272.918378 
 Q 418.987109 277.641704 361.574643 300.497674 
-" clip-path="url(#pcd8c9421ca)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
+" clip-path="url(#pe60783d467)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
     <path d="M 368.258753 301.065709 
 L 361.574643 300.497674 
 L 366.039537 295.491206 
-" clip-path="url(#pcd8c9421ca)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
+" clip-path="url(#pe60783d467)" style="fill: none; stroke: #555555; stroke-width: 1.5; stroke-linecap: round"/>
    </g>
    <g id="patch_14">
     <path d="M 259.117058 117.771971 
@@ -171,7 +171,7 @@ Q 256.922867 89.686333 256.922867 91.880524
 L 256.922867 115.577781 
 Q 256.922867 117.771971 259.117058 117.771971 
 z
-" clip-path="url(#pcd8c9421ca)" style="fill: #c7c7c7; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe60783d467)" style="fill: #c7c7c7; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
     <path d="M 341.618619 204.214188 
@@ -184,7 +184,7 @@ Q 339.424428 176.12855 339.424428 178.322741
 L 339.424428 202.019997 
 Q 339.424428 204.214188 341.618619 204.214188 
 z
-" clip-path="url(#pcd8c9421ca)" style="fill: #98df8a; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe60783d467)" style="fill: #98df8a; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
     <path d="M 225.293767 653.589292 
@@ -197,7 +197,7 @@ Q 223.099577 625.503654 223.099577 627.697844
 L 223.099577 651.395101 
 Q 223.099577 653.589292 225.293767 653.589292 
 z
-" clip-path="url(#pcd8c9421ca)" style="fill: #c7c7c7; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe60783d467)" style="fill: #c7c7c7; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
     <path d="M 53.50088 528.629413 
@@ -210,7 +210,7 @@ Q 51.30669 500.543775 51.30669 502.737965
 L 51.30669 526.435222 
 Q 51.30669 528.629413 53.50088 528.629413 
 z
-" clip-path="url(#pcd8c9421ca)" style="fill: #c7c7c7; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe60783d467)" style="fill: #c7c7c7; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
     <path d="M 324.199654 322.729648 
@@ -223,7 +223,7 @@ Q 322.005463 294.64401 322.005463 296.838201
 L 322.005463 320.535458 
 Q 322.005463 322.729648 324.199654 322.729648 
 z
-" clip-path="url(#pcd8c9421ca)" style="fill: #c7c7c7; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe60783d467)" style="fill: #c7c7c7; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
     <path d="M 487.142154 285.958598 
@@ -236,7 +236,7 @@ Q 484.947963 257.872961 484.947963 260.067151
 L 484.947963 283.764408 
 Q 484.947963 285.958598 487.142154 285.958598 
 z
-" clip-path="url(#pcd8c9421ca)" style="fill: #c7c7c7; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe60783d467)" style="fill: #c7c7c7; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
     <path d="M 204.143219 491.849907 
@@ -249,7 +249,7 @@ Q 201.949029 463.764269 201.949029 465.95846
 L 201.949029 489.655716 
 Q 201.949029 491.849907 204.143219 491.849907 
 z
-" clip-path="url(#pcd8c9421ca)" style="fill: #c7c7c7; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
+" clip-path="url(#pe60783d467)" style="fill: #c7c7c7; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- Battery -->
@@ -1672,7 +1672,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="pcd8c9421ca">
+  <clipPath id="pe60783d467">
    <rect x="7.2" y="37.837813" width="555.206348" height="667.6"/>
   </clipPath>
  </defs>

--- a/tests/scenarios/visualisation/graph.py
+++ b/tests/scenarios/visualisation/graph.py
@@ -16,12 +16,15 @@ import matplotlib.patches as mpatches
 import matplotlib.pyplot as plt
 import networkx as nx
 
-# Use non-GUI backend
-mpl.use("Agg")
-
 from custom_components.haeo.model import Network
 from custom_components.haeo.model.element import Element
 from custom_components.haeo.model.elements import Battery, BatteryBalanceConnection, Connection, Node
+
+# Use non-GUI backend
+mpl.use("Agg")
+
+# Fix SVG hash salt for consistent output
+mpl.rcParams["svg.hashsalt"] = "42"
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
@@ -527,8 +530,6 @@ def create_graph_visualization(
     output_dir = Path(output_path).parent
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    # Ensure hashsalt is set for deterministic SVG IDs (clip-paths, etc.)
-    mpl.rcParams["svg.hashsalt"] = "42"
     plt.savefig(output_path, format="svg", bbox_inches="tight", dpi=300, metadata={"Date": None})
     _LOGGER.info("Graph visualization saved to %s", output_path)
 


### PR DESCRIPTION
The hash at the top of the topology files would change each time which made the git diff show them when it didn't change