### PR TITLE
Remove explicit hass injection

### DIFF
--- a/custom_components/haeo/entities/auto_optimize_switch.py
+++ b/custom_components/haeo/entities/auto_optimize_switch.py
@@ -5,7 +5,6 @@ from typing import Any
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_ON, EntityCategory
-from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntry
 from homeassistant.helpers.restore_state import RestoreEntity
 
@@ -32,7 +31,6 @@ class AutoOptimizeSwitch(SwitchEntity, RestoreEntity):  # pyright: ignore[report
 
     def __init__(
         self,
-        hass: HomeAssistant,
         config_entry: ConfigEntry,
         device_entry: DeviceEntry,
     ) -> None:
@@ -41,7 +39,6 @@ class AutoOptimizeSwitch(SwitchEntity, RestoreEntity):  # pyright: ignore[report
         This switch is a pure state holder with no coordinator knowledge.
         The coordinator subscribes to this switch's state changes.
         """
-        self._hass = hass
         self._config_entry = config_entry
 
         # Link to the network device

--- a/custom_components/haeo/entities/haeo_horizon.py
+++ b/custom_components/haeo/entities/haeo_horizon.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import callback
 from homeassistant.helpers.device_registry import DeviceEntry
 from homeassistant.util import dt as dt_util
 
@@ -35,13 +35,11 @@ class HaeoHorizonEntity(SensorEntity):
 
     def __init__(
         self,
-        hass: HomeAssistant,
         config_entry: ConfigEntry,
         device_entry: DeviceEntry,
         horizon_manager: HorizonManager,
     ) -> None:
         """Initialize the horizon entity."""
-        self._hass = hass
         self._config_entry = config_entry
         self._horizon_manager = horizon_manager
 

--- a/custom_components/haeo/entities/haeo_switch.py
+++ b/custom_components/haeo/entities/haeo_switch.py
@@ -8,7 +8,7 @@ from typing import Any
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.config_entries import ConfigSubentry
 from homeassistant.const import STATE_ON, EntityCategory
-from homeassistant.core import Event, HomeAssistant, callback
+from homeassistant.core import Event, callback
 from homeassistant.helpers.device_registry import DeviceEntry
 from homeassistant.helpers.event import EventStateChangedData, async_track_state_change_event
 from homeassistant.util import dt as dt_util
@@ -46,7 +46,6 @@ class HaeoInputSwitch(SwitchEntity):
 
     def __init__(
         self,
-        hass: HomeAssistant,
         config_entry: HaeoConfigEntry,
         subentry: ConfigSubentry,
         field_info: InputFieldInfo[SwitchEntityDescription],
@@ -55,7 +54,6 @@ class HaeoInputSwitch(SwitchEntity):
         field_path: InputFieldPath | None = None,
     ) -> None:
         """Initialize the input switch entity."""
-        self._hass = hass
         self._config_entry: HaeoConfigEntry = config_entry
         self._subentry = subentry
         self._field_info = field_info
@@ -157,7 +155,7 @@ class HaeoInputSwitch(SwitchEntity):
             if self._source_entity_id is not None:
                 self.async_on_remove(
                     async_track_state_change_event(
-                        self._hass,
+                        self.hass,
                         [self._source_entity_id],
                         self._handle_source_state_change,
                     )
@@ -190,7 +188,7 @@ class HaeoInputSwitch(SwitchEntity):
         if self._source_entity_id is None:
             return
 
-        state = self._hass.states.get(self._source_entity_id)
+        state = self.hass.states.get(self._source_entity_id)
         if state is not None:
             self._attr_is_on = state.state == STATE_ON
             self._update_forecast()
@@ -266,7 +264,7 @@ class HaeoInputSwitch(SwitchEntity):
 
         # Persist to config entry so value survives restarts and shows in reconfigure
         await async_update_subentry_value(
-            self._hass,
+            self.hass,
             self._config_entry,
             self._subentry,
             field_path=self._field_path,
@@ -292,7 +290,7 @@ class HaeoInputSwitch(SwitchEntity):
 
         # Persist to config entry so value survives restarts and shows in reconfigure
         await async_update_subentry_value(
-            self._hass,
+            self.hass,
             self._config_entry,
             self._subentry,
             field_path=self._field_path,

--- a/custom_components/haeo/number.py
+++ b/custom_components/haeo/number.py
@@ -69,7 +69,6 @@ async def async_setup_entry(
                 continue
 
             entity = HaeoInputNumber(
-                hass=hass,
                 config_entry=config_entry,
                 subentry=subentry,
                 field_info=field_info,

--- a/custom_components/haeo/sensor.py
+++ b/custom_components/haeo/sensor.py
@@ -56,7 +56,6 @@ async def async_setup_entry(
 
     # Create horizon entity that displays horizon manager state
     horizon_entity = HaeoHorizonEntity(
-        hass=hass,
         config_entry=config_entry,
         device_entry=network_device_entry,
         horizon_manager=horizon_manager,

--- a/custom_components/haeo/switch.py
+++ b/custom_components/haeo/switch.py
@@ -74,7 +74,6 @@ async def async_setup_entry(
                 continue
 
             entity = HaeoInputSwitch(
-                hass=hass,
                 config_entry=config_entry,
                 subentry=subentry,
                 field_info=field_info,
@@ -94,7 +93,6 @@ async def async_setup_entry(
 
     network_device = get_or_create_network_device(hass, config_entry, network_subentry)
     auto_optimize_switch = AutoOptimizeSwitch(
-        hass=hass,
         config_entry=config_entry,
         device_entry=network_device,
     )

--- a/tests/entities/test_haeo_horizon.py
+++ b/tests/entities/test_haeo_horizon.py
@@ -1,11 +1,14 @@
 """Tests for the HAEO horizon entity."""
 
-from datetime import datetime
+from datetime import datetime, timedelta
+import logging
 from unittest.mock import Mock
 
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntry
+from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.entity_platform import EntityPlatform
 from homeassistant.util import dt as dt_util
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -57,6 +60,21 @@ def device_entry() -> Mock:
     return device
 
 
+async def _add_entity_to_hass(hass: HomeAssistant, entity: Entity) -> None:
+    """Add entity to Home Assistant via a real EntityPlatform."""
+    platform = EntityPlatform(
+        hass=hass,
+        logger=logging.getLogger(__name__),
+        domain="sensor",
+        platform_name=DOMAIN,
+        platform=None,
+        scan_interval=timedelta(seconds=30),
+        entity_namespace=None,
+    )
+    await platform.async_add_entities([entity])
+    await hass.async_block_till_done()
+
+
 # --- Tests for initialization ---
 
 
@@ -68,7 +86,6 @@ def test_horizon_entity_initialization(
 ) -> None:
     """Horizon entity initializes with correct attributes."""
     entity = HaeoHorizonEntity(
-        hass=hass,
         config_entry=config_entry,
         device_entry=device_entry,
         horizon_manager=horizon_manager,
@@ -91,7 +108,6 @@ def test_entity_reflects_horizon_manager_timestamps(
 ) -> None:
     """Entity reflects timestamps from horizon manager."""
     entity = HaeoHorizonEntity(
-        hass=hass,
         config_entry=config_entry,
         device_entry=device_entry,
         horizon_manager=horizon_manager,
@@ -125,7 +141,6 @@ def test_extra_state_attributes(
 ) -> None:
     """Entity has expected extra state attributes."""
     entity = HaeoHorizonEntity(
-        hass=hass,
         config_entry=config_entry,
         device_entry=device_entry,
         horizon_manager=horizon_manager,
@@ -149,7 +164,6 @@ def test_forecast_attribute_contains_timestamps(
 ) -> None:
     """Forecast attribute contains list of timestamp dicts."""
     entity = HaeoHorizonEntity(
-        hass=hass,
         config_entry=config_entry,
         device_entry=device_entry,
         horizon_manager=horizon_manager,
@@ -178,7 +192,6 @@ def test_native_value_is_start_time_iso(
 ) -> None:
     """Native value is the start timestamp in ISO format."""
     entity = HaeoHorizonEntity(
-        hass=hass,
         config_entry=config_entry,
         device_entry=device_entry,
         horizon_manager=horizon_manager,
@@ -200,7 +213,6 @@ def test_entity_category_is_diagnostic(
 ) -> None:
     """Entity should be DIAGNOSTIC category."""
     entity = HaeoHorizonEntity(
-        hass=hass,
         config_entry=config_entry,
         device_entry=device_entry,
         horizon_manager=horizon_manager,
@@ -220,13 +232,12 @@ async def test_async_added_to_hass_subscribes_to_manager(
 ) -> None:
     """Adding entity to hass subscribes to horizon manager."""
     entity = HaeoHorizonEntity(
-        hass=hass,
         config_entry=config_entry,
         device_entry=device_entry,
         horizon_manager=horizon_manager,
     )
 
-    await entity.async_added_to_hass()
+    await _add_entity_to_hass(hass, entity)
 
     # Entity should have state attributes after being added
     assert entity.extra_state_attributes is not None
@@ -240,7 +251,6 @@ async def test_horizon_entity_updates_on_manager_change(
 ) -> None:
     """Entity updates state when horizon manager changes."""
     entity = HaeoHorizonEntity(
-        hass=hass,
         config_entry=config_entry,
         device_entry=device_entry,
         horizon_manager=horizon_manager,
@@ -249,7 +259,8 @@ async def test_horizon_entity_updates_on_manager_change(
     # Mock async_write_ha_state
     entity.async_write_ha_state = Mock()  # type: ignore[method-assign]
 
-    await entity.async_added_to_hass()
+    await _add_entity_to_hass(hass, entity)
+    entity.async_write_ha_state.reset_mock()
 
     # Call the horizon change handler directly
     entity._async_horizon_changed()

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -372,7 +372,6 @@ async def test_auto_optimize_switch_turn_on(hass: HomeAssistant) -> None:
     entry.add_to_hass(hass)
 
     switch = AutoOptimizeSwitch(
-        hass=hass,
         config_entry=entry,
         device_entry=_create_mock_device_entry(),
     )
@@ -395,7 +394,6 @@ async def test_auto_optimize_switch_turn_off(hass: HomeAssistant) -> None:
     entry.add_to_hass(hass)
 
     switch = AutoOptimizeSwitch(
-        hass=hass,
         config_entry=entry,
         device_entry=_create_mock_device_entry(),
     )
@@ -418,7 +416,6 @@ async def test_auto_optimize_switch_restores_on_state(hass: HomeAssistant) -> No
     entry.add_to_hass(hass)
 
     switch = AutoOptimizeSwitch(
-        hass=hass,
         config_entry=entry,
         device_entry=_create_mock_device_entry(),
     )
@@ -442,7 +439,6 @@ async def test_auto_optimize_switch_restores_off_state(hass: HomeAssistant) -> N
     entry.add_to_hass(hass)
 
     switch = AutoOptimizeSwitch(
-        hass=hass,
         config_entry=entry,
         device_entry=_create_mock_device_entry(),
     )
@@ -466,7 +462,6 @@ async def test_auto_optimize_switch_defaults_to_on_without_previous_state(hass: 
     entry.add_to_hass(hass)
 
     switch = AutoOptimizeSwitch(
-        hass=hass,
         config_entry=entry,
         device_entry=_create_mock_device_entry(),
     )


### PR DESCRIPTION
## Summary
- remove explicit hass parameters from entities and use `Entity.hass`
- update entity setup call sites to match constructor changes
- update switch/horizon tests to add entities via `EntityPlatform`

## Testing
- uv run pytest tests/entities/test_haeo_switch.py
- uv run pytest tests/entities/test_haeo_horizon.py