### PR TITLE
Fix optimizer crash when optional efficiency is unset

### DIFF
--- a/custom_components/haeo/coordinator/tests/test_network.py
+++ b/custom_components/haeo/coordinator/tests/test_network.py
@@ -8,7 +8,7 @@ from custom_components.haeo.core.const import CONF_ELEMENT_TYPE, CONF_NAME
 from custom_components.haeo.core.model import Network
 from custom_components.haeo.core.model.elements import MODEL_ELEMENT_TYPE_CONNECTION, MODEL_ELEMENT_TYPE_NODE
 from custom_components.haeo.core.model.elements.connection import Connection
-from custom_components.haeo.core.model.elements.segments import PowerLimitSegment
+from custom_components.haeo.core.model.elements.segments import EfficiencySegment, PowerLimitSegment
 from custom_components.haeo.core.schema import as_connection_target
 from custom_components.haeo.core.schema.elements import ElementConfigData, ElementType
 from custom_components.haeo.core.schema.elements.connection import (
@@ -102,3 +102,56 @@ def test_update_element_raises_for_missing_model_element() -> None:
 
     with pytest.raises(ValueError, match="Model element 'nonexistent_conn' not found in network during update"):
         update_element(network, config)
+
+
+def test_update_element_allows_empty_efficiency_section() -> None:
+    """Clearing optional efficiency should behave as 100% and not crash optimization."""
+    network = Network(name="test", periods=np.array([1.0, 1.0]))
+    network.add({"element_type": MODEL_ELEMENT_TYPE_NODE, "name": "source", "is_source": True, "is_sink": False})
+    network.add({"element_type": MODEL_ELEMENT_TYPE_NODE, "name": "target", "is_source": False, "is_sink": True})
+    network.add(
+        {
+            "element_type": MODEL_ELEMENT_TYPE_CONNECTION,
+            "name": "conn",
+            "source": "source",
+            "target": "target",
+            "segments": {
+                "efficiency": {
+                    "segment_type": "efficiency",
+                    "efficiency_source_target": np.array([0.95, 0.95]),
+                    "efficiency_target_source": np.array([0.95, 0.95]),
+                },
+                "power_limit": {
+                    "segment_type": "power_limit",
+                    "max_power_source_target": np.array([10.0, 10.0]),
+                    "max_power_target_source": np.array([10.0, 10.0]),
+                },
+            },
+        }
+    )
+
+    config: ElementConfigData = {
+        CONF_ELEMENT_TYPE: ElementType.CONNECTION,
+        CONF_NAME: "conn",
+        SECTION_ENDPOINTS: {
+            "source": as_connection_target("source"),
+            "target": as_connection_target("target"),
+        },
+        SECTION_POWER_LIMITS: {
+            CONF_MAX_POWER_SOURCE_TARGET: np.array([10.0, 10.0]),
+            CONF_MAX_POWER_TARGET_SOURCE: np.array([10.0, 10.0]),
+        },
+        SECTION_PRICING: {},
+        SECTION_EFFICIENCY: {},
+    }
+    update_element(network, config)
+
+    conn = network.elements["conn"]
+    assert isinstance(conn, Connection)
+    efficiency = conn.segments["efficiency"]
+    assert isinstance(efficiency, EfficiencySegment)
+    assert efficiency.efficiency_source_target is None
+    assert efficiency.efficiency_target_source is None
+
+    # Regression check: this previously raised HiGHS "Unexpected parameters".
+    network.optimize()

--- a/custom_components/haeo/core/data/loader/config_loader.py
+++ b/custom_components/haeo/core/data/loader/config_loader.py
@@ -76,13 +76,20 @@ def load_element_config(
         for field_name, hint in section_fields.items():
             value = section_config.get(field_name)
             if value is None:
+                if (default := _default_for_hint(hint, forecast_times)) is not _REMOVE:
+                    loaded.setdefault(section_name, {})[field_name] = default
                 continue
 
             resolved = _resolve_field(value, hint, sm, forecast_times)
             if resolved is _REMOVE:
-                loaded_section = loaded.get(section_name)
-                if isinstance(loaded_section, dict):
-                    loaded_section.pop(field_name, None)
+                if (default := _default_for_hint(hint, forecast_times)) is not _REMOVE:
+                    loaded.setdefault(section_name, {})[field_name] = default
+                else:
+                    loaded_section = loaded.get(section_name)
+                    if isinstance(loaded_section, dict):
+                        loaded_section.pop(field_name, None)
+            elif resolved is None and (default := _default_for_hint(hint, forecast_times)) is not _REMOVE:
+                loaded.setdefault(section_name, {})[field_name] = default
             else:
                 loaded.setdefault(section_name, {})[field_name] = resolved
 
@@ -113,6 +120,13 @@ class _Sentinel:
 
 
 _REMOVE = _Sentinel()
+
+
+def _default_for_hint(hint: FieldHint, forecast_times: Sequence[float]) -> _Sentinel | float | np.ndarray:
+    """Return a type-driven default value for optional fields."""
+    if hint.output_type is not OutputType.EFFICIENCY:
+        return _REMOVE
+    return _resolve_numeric(100.0, hint, forecast_times, is_percent=True)
 
 
 def _resolve_field(

--- a/custom_components/haeo/core/data/loader/tests/test_config_loader.py
+++ b/custom_components/haeo/core/data/loader/tests/test_config_loader.py
@@ -66,16 +66,8 @@ def _inverter_config(*, efficiency_source_target: Any = None, efficiency_target_
             "max_power_target_source": {"type": "constant", "value": 10.0},
         },
         "efficiency": {
-            **(
-                {"efficiency_source_target": efficiency_source_target}
-                if efficiency_source_target is not None
-                else {}
-            ),
-            **(
-                {"efficiency_target_source": efficiency_target_source}
-                if efficiency_target_source is not None
-                else {}
-            ),
+            **({"efficiency_source_target": efficiency_source_target} if efficiency_source_target is not None else {}),
+            **({"efficiency_target_source": efficiency_target_source} if efficiency_target_source is not None else {}),
         },
     }
 
@@ -88,16 +80,8 @@ def _connection_config(*, efficiency_source_target: Any = None, efficiency_targe
         "pricing": {},
         "power_limits": {},
         "efficiency": {
-            **(
-                {"efficiency_source_target": efficiency_source_target}
-                if efficiency_source_target is not None
-                else {}
-            ),
-            **(
-                {"efficiency_target_source": efficiency_target_source}
-                if efficiency_target_source is not None
-                else {}
-            ),
+            **({"efficiency_source_target": efficiency_source_target} if efficiency_source_target is not None else {}),
+            **({"efficiency_target_source": efficiency_target_source} if efficiency_target_source is not None else {}),
         },
     }
 
@@ -169,6 +153,14 @@ class TestLoadElementConfig:
         """None-typed values remove the field from loaded config."""
         result = _load_grid(_grid_config(export_price={"type": "none"}))
 
+        assert "price_target_source" not in result["pricing"]
+
+    def test_missing_non_efficiency_optional_field_is_not_defaulted(self) -> None:
+        """Missing non-efficiency optional fields remain absent."""
+        config = _grid_config()
+        config["pricing"].pop("price_target_source")
+
+        result = _load_grid(config)
         assert "price_target_source" not in result["pricing"]
 
     @pytest.mark.parametrize(

--- a/custom_components/haeo/core/data/loader/tests/test_config_loader.py
+++ b/custom_components/haeo/core/data/loader/tests/test_config_loader.py
@@ -9,6 +9,7 @@ import pytest
 from conftest import FakeStateMachine
 from custom_components.haeo.core.data.loader import config_loader as cl
 from custom_components.haeo.core.data.loader.config_loader import load_element_config, load_element_configs
+from custom_components.haeo.core.schema import as_connection_target
 from custom_components.haeo.core.schema.elements import ElementConfigSchema
 
 FORECAST_TIMES = (0.0, 3600.0, 7200.0, 10800.0)
@@ -55,6 +56,52 @@ def _battery_config(
     }
 
 
+def _inverter_config(*, efficiency_source_target: Any = None, efficiency_target_source: Any = None) -> dict[str, Any]:
+    return {
+        "element_type": "inverter",
+        "name": "Inverter",
+        "connection": as_connection_target("node_a"),
+        "power_limits": {
+            "max_power_source_target": {"type": "constant", "value": 10.0},
+            "max_power_target_source": {"type": "constant", "value": 10.0},
+        },
+        "efficiency": {
+            **(
+                {"efficiency_source_target": efficiency_source_target}
+                if efficiency_source_target is not None
+                else {}
+            ),
+            **(
+                {"efficiency_target_source": efficiency_target_source}
+                if efficiency_target_source is not None
+                else {}
+            ),
+        },
+    }
+
+
+def _connection_config(*, efficiency_source_target: Any = None, efficiency_target_source: Any = None) -> dict[str, Any]:
+    return {
+        "element_type": "connection",
+        "name": "Connection",
+        "endpoints": {"source": as_connection_target("node_a"), "target": as_connection_target("node_b")},
+        "pricing": {},
+        "power_limits": {},
+        "efficiency": {
+            **(
+                {"efficiency_source_target": efficiency_source_target}
+                if efficiency_source_target is not None
+                else {}
+            ),
+            **(
+                {"efficiency_target_source": efficiency_target_source}
+                if efficiency_target_source is not None
+                else {}
+            ),
+        },
+    }
+
+
 def _as_schema(config: dict[str, Any]) -> ElementConfigSchema:
     """Cast a test config dict to ElementConfigSchema at the type boundary."""
     return cast("ElementConfigSchema", config)
@@ -71,6 +118,12 @@ def _load_battery(config: dict[str, Any] | None = None) -> dict[str, Any]:
     result = load_element_config(
         "Battery", _as_schema(config or _battery_config()), FakeStateMachine({}), FORECAST_TIMES
     )
+    return cast("dict[str, Any]", result)
+
+
+def _load_element(name: str, config: dict[str, Any]) -> dict[str, Any]:
+    """Load an element config and return as plain dict for assertion."""
+    result = load_element_config(name, _as_schema(config), FakeStateMachine({}), FORECAST_TIMES)
     return cast("dict[str, Any]", result)
 
 
@@ -117,6 +170,71 @@ class TestLoadElementConfig:
         result = _load_grid(_grid_config(export_price={"type": "none"}))
 
         assert "price_target_source" not in result["pricing"]
+
+    @pytest.mark.parametrize(
+        ("element_name", "config"),
+        [
+            ("Inverter", _inverter_config()),
+            ("Battery", {**_battery_config(), "efficiency": {}}),
+            ("Connection", _connection_config()),
+        ],
+        ids=("inverter", "battery", "connection"),
+    )
+    def test_missing_efficiency_fields_default_to_unity_by_type(
+        self,
+        element_name: str,
+        config: dict[str, Any],
+    ) -> None:
+        """Efficiency-typed optional fields default to 100% for all element types."""
+        result = _load_element(element_name, config)
+        np.testing.assert_allclose(result["efficiency"]["efficiency_source_target"], [1.0, 1.0, 1.0])
+        np.testing.assert_allclose(result["efficiency"]["efficiency_target_source"], [1.0, 1.0, 1.0])
+
+    @pytest.mark.parametrize(
+        ("element_name", "config"),
+        [
+            (
+                "Inverter",
+                _inverter_config(
+                    efficiency_source_target={"type": "none"},
+                    efficiency_target_source={"type": "none"},
+                ),
+            ),
+            (
+                "Connection",
+                _connection_config(
+                    efficiency_source_target={"type": "none"},
+                    efficiency_target_source={"type": "none"},
+                ),
+            ),
+        ],
+        ids=("inverter_none", "connection_none"),
+    )
+    def test_none_efficiency_values_default_to_unity_by_type(
+        self,
+        element_name: str,
+        config: dict[str, Any],
+    ) -> None:
+        """None-typed efficiency values resolve to 100% defaults."""
+        result = _load_element(element_name, config)
+        np.testing.assert_allclose(result["efficiency"]["efficiency_source_target"], [1.0, 1.0, 1.0])
+        np.testing.assert_allclose(result["efficiency"]["efficiency_target_source"], [1.0, 1.0, 1.0])
+
+    def test_unavailable_efficiency_entity_defaults_to_unity(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Unavailable efficiency entity data falls back to 100% defaults."""
+
+        def fake_load_sensors(_sm: Any, entity_ids: Sequence[str]) -> dict[str, float]:
+            return {}
+
+        monkeypatch.setattr(cl, "load_sensors", fake_load_sensors)
+
+        config = _inverter_config(
+            efficiency_source_target={"type": "entity", "value": ["sensor.missing_eff_st"]},
+            efficiency_target_source={"type": "entity", "value": ["sensor.missing_eff_ts"]},
+        )
+        result = _load_element("Inverter", config)
+        np.testing.assert_allclose(result["efficiency"]["efficiency_source_target"], [1.0, 1.0, 1.0])
+        np.testing.assert_allclose(result["efficiency"]["efficiency_target_source"], [1.0, 1.0, 1.0])
 
     def test_entity_value_loads_from_state_machine(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Entity values resolve through sensor loading pipeline."""

--- a/custom_components/haeo/core/model/elements/segments/efficiency.py
+++ b/custom_components/haeo/core/model/elements/segments/efficiency.py
@@ -39,8 +39,8 @@ class EfficiencySegment(Segment):
     Efficiency values are fractions in range (0, 1].
     """
 
-    efficiency_source_target: TrackedParam[NDArray[np.float64]] = TrackedParam()
-    efficiency_target_source: TrackedParam[NDArray[np.float64]] = TrackedParam()
+    efficiency_source_target: TrackedParam[NDArray[np.float64] | None] = TrackedParam()
+    efficiency_target_source: TrackedParam[NDArray[np.float64] | None] = TrackedParam()
 
     def __init__(
         self,
@@ -76,13 +76,9 @@ class EfficiencySegment(Segment):
 
         # Store efficiency values
         efficiency_source_target = spec.get("efficiency_source_target")
-        self.efficiency_source_target = broadcast_to_sequence(
-            1.0 if efficiency_source_target is None else efficiency_source_target, self._n_periods
-        )
+        self.efficiency_source_target = broadcast_to_sequence(efficiency_source_target, self._n_periods)
         efficiency_target_source = spec.get("efficiency_target_source")
-        self.efficiency_target_source = broadcast_to_sequence(
-            1.0 if efficiency_target_source is None else efficiency_target_source, self._n_periods
-        )
+        self.efficiency_target_source = broadcast_to_sequence(efficiency_target_source, self._n_periods)
 
         # Single variable per direction - efficiency applied via properties
         self._power_st = solver.addVariables(n_periods, lb=0, name_prefix=f"{segment_id}_st_", out_array=True)
@@ -96,7 +92,11 @@ class EfficiencySegment(Segment):
     @property
     def power_out_st(self) -> HighspyArray:
         """Power leaving segment in source→target direction (after efficiency loss)."""
-        return self._power_st * self.efficiency_source_target
+        efficiency = self.efficiency_source_target
+        if efficiency is None:
+            # Missing optional efficiency means no losses (100%).
+            return self._power_st
+        return self._power_st * efficiency
 
     @property
     def power_in_ts(self) -> HighspyArray:
@@ -106,7 +106,11 @@ class EfficiencySegment(Segment):
     @property
     def power_out_ts(self) -> HighspyArray:
         """Power leaving segment in target→source direction (after efficiency loss)."""
-        return self._power_ts * self.efficiency_target_source
+        efficiency = self.efficiency_target_source
+        if efficiency is None:
+            # Missing optional efficiency means no losses (100%).
+            return self._power_ts
+        return self._power_ts * efficiency
 
 
 __all__ = ["EfficiencySegment", "EfficiencySegmentSpec"]

--- a/custom_components/haeo/core/model/elements/segments/tests/test_segments.py
+++ b/custom_components/haeo/core/model/elements/segments/tests/test_segments.py
@@ -411,3 +411,27 @@ def test_efficiency_segment_treats_none_as_unity_after_update() -> None:
     h.run()
 
     np.testing.assert_allclose(h.vals(segment.power_out_ts), [10.0], rtol=1e-6, atol=1e-6)
+
+
+def test_efficiency_segment_treats_missing_values_as_unity_both_directions() -> None:
+    """Missing efficiency values should keep both directions lossless."""
+    h = create_solver()
+    periods = np.asarray([1.0], dtype=np.float64)
+    source = DummyElement("source", periods, h)
+    target = DummyElement("target", periods, h)
+    segment = EfficiencySegment(
+        "seg",
+        len(periods),
+        periods,
+        h,
+        spec={"segment_type": "efficiency"},
+        source_element=source,
+        target_element=target,
+    )
+
+    h.addConstrs(segment.power_in_st == np.asarray([7.5], dtype=np.float64))
+    h.addConstrs(segment.power_in_ts == np.asarray([3.5], dtype=np.float64))
+    h.run()
+
+    np.testing.assert_allclose(h.vals(segment.power_out_st), [7.5], rtol=1e-6, atol=1e-6)
+    np.testing.assert_allclose(h.vals(segment.power_out_ts), [3.5], rtol=1e-6, atol=1e-6)

--- a/custom_components/haeo/core/model/elements/segments/tests/test_segments.py
+++ b/custom_components/haeo/core/model/elements/segments/tests/test_segments.py
@@ -13,6 +13,7 @@ from custom_components.haeo.core.model.const import OutputType
 from custom_components.haeo.core.model.element import Element
 from custom_components.haeo.core.model.elements.connection import Connection
 from custom_components.haeo.core.model.elements.segments import (
+    EfficiencySegment,
     PowerLimitSegment,
     PricingSegment,
     SocPricingSegment,
@@ -386,3 +387,27 @@ def test_soc_pricing_cost_none_without_prices() -> None:
     )
 
     assert segment.cost() is None
+
+
+def test_efficiency_segment_treats_none_as_unity_after_update() -> None:
+    """Efficiency segment should treat None values as 100% efficiency."""
+    h = create_solver()
+    periods = np.asarray([1.0], dtype=np.float64)
+    source = DummyElement("source", periods, h)
+    target = DummyElement("target", periods, h)
+    segment = EfficiencySegment(
+        "seg",
+        len(periods),
+        periods,
+        h,
+        spec={"segment_type": "efficiency", "efficiency_target_source": np.array([0.9], dtype=np.float64)},
+        source_element=source,
+        target_element=target,
+    )
+
+    # Simulate coordinator update path clearing optional efficiency.
+    segment.efficiency_target_source = None
+    h.addConstrs(segment.power_in_ts == np.asarray([10.0], dtype=np.float64))
+    h.run()
+
+    np.testing.assert_allclose(h.vals(segment.power_out_ts), [10.0], rtol=1e-6, atol=1e-6)


### PR DESCRIPTION
## Summary
- fix `EfficiencySegment` to treat missing/cleared optional efficiency values as unity (100%) so expressions remain valid and lossless behavior matches legacy defaults
- preserve update semantics where clearing efficiency fields sends `None` through reactive updates without crashing HiGHS
- add regression coverage for both direct segment behavior and coordinator `update_element` flow with an empty efficiency section

## Test plan
- [x] `uv run pytest custom_components/haeo/core/model/elements/segments/tests/test_segments.py -k \"efficiency_segment_treats_none_as_unity_after_update\"`
- [x] `uv run pytest custom_components/haeo/coordinator/tests/test_network.py -k \"empty_efficiency_section\"`
- [x] `uv run ruff check custom_components/haeo/core/model/elements/segments/efficiency.py custom_components/haeo/core/model/elements/segments/tests/test_segments.py custom_components/haeo/coordinator/tests/test_network.py`
- [x] `uv run pyright custom_components/haeo/core/model/elements/segments/efficiency.py custom_components/haeo/core/model/elements/segments/tests/test_segments.py custom_components/haeo/coordinator/tests/test_network.py`

Made with [Cursor](https://cursor.com)