### PR TITLE
feat: guide tooling infrastructure improvements

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -105,6 +105,9 @@ markdown_extensions:
         - name: guide
           class: guide
           format: !!python/name:tools.guide_fence.format_guide
+        - name: guide-setup
+          class: guide-setup
+          format: !!python/name:tools.guide_fence.format_guide_setup
   - pymdownx.tabbed:
       alternate_style: true
   - pymdownx.tasklist:

--- a/tests/guides/ha_runner.py
+++ b/tests/guides/ha_runner.py
@@ -373,6 +373,8 @@ async def _setup_home_assistant_async(
 
     assert await async_setup_component(hass, "frontend", {})
     assert await async_setup_component(hass, "config", {})
+    assert await async_setup_component(hass, "calendar", {})
+    assert await async_setup_component(hass, "local_calendar", {})
 
     # Mark as running
     hass.set_state(CoreState.running)

--- a/tests/guides/primitives/__init__.py
+++ b/tests/guides/primitives/__init__.py
@@ -17,7 +17,7 @@ Example usage:
         # ctx.screenshots contains OrderedDict of all captured images
 """
 
-from tests.guides.primitives.capture import ScreenshotContext, guide_step, screenshot_context
+from tests.guides.primitives.capture import ScreenshotContext, guide_step, pause_screenshots, screenshot_context
 from tests.guides.primitives.ha_page import HAPage
 from tests.guides.primitives.haeo import (
     ConstantInput,
@@ -51,6 +51,7 @@ __all__ = [
     "add_solar",
     "guide_step",
     "login",
+    "pause_screenshots",
     "screenshot_context",
     "verify_setup",
 ]

--- a/tests/guides/primitives/capture.py
+++ b/tests/guides/primitives/capture.py
@@ -118,6 +118,22 @@ class ScreenshotContext:
 
 
 @contextmanager
+def pause_screenshots() -> Iterator[None]:
+    """Temporarily suppress screenshot capture.
+
+    All guide primitives called within this context will execute normally
+    but skip screenshot capture. Used by run_guide() to replay a
+    prerequisite guide silently.
+    """
+    previous = _holder.current
+    _holder.current = None
+    try:
+        yield
+    finally:
+        _holder.current = previous
+
+
+@contextmanager
 def screenshot_context(output_dir: Path) -> Iterator[ScreenshotContext]:
     """Create a screenshot collection context.
 

--- a/tests/guides/primitives/ha_page.py
+++ b/tests/guides/primitives/ha_page.py
@@ -547,20 +547,13 @@ class HAPage:
 
                 picker.click()
 
-                # Entity picker opens an inline dropdown with a search box
-                combo_selector = "vaadin-combo-box-overlay input, ha-combo-box input[type='search']"
-                search_input = self.page.locator(combo_selector).first
-                if not search_input.is_visible(timeout=1000):
-                    # Fallback: find the search textbox that appeared
-                    search_input = self.page.get_by_role("textbox", name="Search")
+                search_input = self.page.locator("vaadin-combo-box-overlay input").first
                 search_input.wait_for(state="visible", timeout=DEFAULT_TIMEOUT)
                 self._capture_with_indicator("search_box", search_input)
 
                 search_input.fill(search_term)
 
                 result_item = self.page.locator(f"ha-combo-box-item:has-text('{entity_name}')").first
-                if not result_item.is_visible(timeout=1000):
-                    result_item = self.page.locator(f":text('{entity_name}')").first
                 result_item.wait_for(state="visible", timeout=SEARCH_TIMEOUT)
                 self._capture("search_results")
                 self._capture_with_indicator("select", result_item)
@@ -570,15 +563,10 @@ class HAPage:
                 self._capture("selected")
         else:
             picker.click()
-            combo_selector = "vaadin-combo-box-overlay input, ha-combo-box input[type='search']"
-            search_input = self.page.locator(combo_selector).first
-            if not search_input.is_visible(timeout=1000):
-                search_input = self.page.get_by_role("textbox", name="Search")
+            search_input = self.page.locator("vaadin-combo-box-overlay input").first
             search_input.wait_for(state="visible", timeout=DEFAULT_TIMEOUT)
             search_input.fill(search_term)
             result_item = self.page.locator(f"ha-combo-box-item:has-text('{entity_name}')").first
-            if not result_item.is_visible(timeout=1000):
-                result_item = self.page.locator(f":text('{entity_name}')").first
             result_item.wait_for(state="visible", timeout=SEARCH_TIMEOUT)
             result_item.click(timeout=DEFAULT_TIMEOUT)
             self.page.wait_for_timeout(500)
@@ -728,14 +716,8 @@ class HAPage:
         """)
 
     def click_add_integration(self) -> None:
-        """Click the Add integration button.
-
-        The button may be rendered as ha-button or ha-fab depending on
-        context. Try ha-fab first (integrations list), then ha-button.
-        """
+        """Click the Add integration FAB on the integrations list page."""
         add_btn = self.page.locator("ha-fab").get_by_role("button", name="Add integration")
-        if not add_btn.is_visible(timeout=1000):
-            add_btn = self.page.locator("ha-button").get_by_role("button", name="Add integration")
         add_btn.wait_for(state="visible", timeout=SEARCH_TIMEOUT)
 
         ctx = ScreenshotContext.current()
@@ -792,10 +774,7 @@ class HAPage:
         ctx = ScreenshotContext.current()
 
         # Click the add event FAB
-        add_btn = self.page.locator("ha-fab, ha-assist-chip").filter(has_text="event").first
-        if not add_btn.is_visible(timeout=1000):
-            # Try the material FAB button
-            add_btn = self.page.get_by_role("button", name="event")
+        add_btn = self.page.locator("ha-fab").first
         add_btn.wait_for(state="visible", timeout=DEFAULT_TIMEOUT)
 
         if ctx:
@@ -812,8 +791,6 @@ class HAPage:
 
                 # Fill title
                 title_input = dialog.get_by_role("textbox", name="Title")
-                if not title_input.is_visible(timeout=1000):
-                    title_input = dialog.get_by_role("textbox").first
                 title_input.wait_for(state="visible", timeout=DEFAULT_TIMEOUT)
                 self._capture_with_indicator("title_field", title_input)
                 title_input.fill(title)
@@ -832,9 +809,8 @@ class HAPage:
                     self._set_event_recurrence(dialog, recurrence)
 
                 # Save the event
-                save_btn = dialog.locator("mwc-button[slot='primaryAction'], ha-button[slot='primaryAction']").first
-                if not save_btn.is_visible(timeout=1000):
-                    save_btn = dialog.get_by_text("Add event").last
+                save_btn = dialog.locator("ha-button[slot='primaryAction']").first
+                save_btn.wait_for(state="visible", timeout=DEFAULT_TIMEOUT)
                 # Use the inner button for proper border-radius highlighting
                 inner_btn = save_btn.locator("button").first
                 if inner_btn.is_visible(timeout=500):
@@ -852,8 +828,6 @@ class HAPage:
             dialog = self.page.locator("ha-dialog[open]")
             dialog.wait_for(state="attached", timeout=DEFAULT_TIMEOUT)
             title_input = dialog.get_by_role("textbox", name="Title")
-            if not title_input.is_visible(timeout=1000):
-                title_input = dialog.get_by_role("textbox").first
             title_input.fill(title)
             if location:
                 location_input = dialog.get_by_role("textbox", name="Location")
@@ -861,9 +835,7 @@ class HAPage:
             self._fill_event_times(dialog, start_time, end_time)
             if recurrence:
                 self._set_event_recurrence(dialog, recurrence)
-            save_btn = dialog.locator("mwc-button[slot='primaryAction'], ha-button[slot='primaryAction']").first
-            if not save_btn.is_visible(timeout=1000):
-                save_btn = dialog.get_by_text("Add event").last
+            save_btn = dialog.locator("ha-button[slot='primaryAction']").first
             save_btn.click()
             dialog.wait_for(state="hidden", timeout=SEARCH_TIMEOUT)
 
@@ -886,17 +858,14 @@ class HAPage:
         # Toggle off all-day if we're setting specific times
         if start_time or end_time:
             all_day_toggle = dialog.locator("ha-formfield").filter(has_text="All day")
-            if not all_day_toggle.is_visible(timeout=500):
-                all_day_toggle = dialog.locator("label").filter(has_text="All day")
-            if all_day_toggle.is_visible(timeout=1000):
-                # Check if the toggle is currently ON by inspecting the switch state
-                switch = all_day_toggle.locator("ha-switch")
-                is_checked = switch.evaluate("(el) => el.checked === true") if switch.is_visible(timeout=500) else False
-                if is_checked:
-                    if ctx:
-                        self._capture_with_indicator("all_day_toggle", all_day_toggle)
-                    all_day_toggle.click()
-                    self.page.wait_for_timeout(500)
+            all_day_toggle.wait_for(state="visible", timeout=DEFAULT_TIMEOUT)
+            switch = all_day_toggle.locator("ha-switch")
+            is_checked = switch.evaluate("(el) => el.checked === true")
+            if is_checked:
+                if ctx:
+                    self._capture_with_indicator("all_day_toggle", all_day_toggle)
+                all_day_toggle.click()
+                self.page.wait_for_timeout(500)
 
         time_inputs = dialog.locator("ha-time-input")
 
@@ -939,38 +908,30 @@ class HAPage:
 
         # Set AM/PM first to avoid HA auto-adjusting end time
         # when the period changes mid-edit.
-        period_select = time_input.locator("ha-select, select, [role='listbox']").first
-        if not period_select.is_visible(timeout=500):
-            period_select = time_input.locator("mwc-select").first
-        if period_select.is_visible(timeout=500):
-            # Check current period by reading the selected value attribute
-            current_period = period_select.evaluate("(el) => el.value || el.textContent.trim().split('\\n')[0].trim()")
-            if current_period != period:
-                period_select.click()
-                option = self.page.get_by_role("option", name=period)
-                if not option.is_visible(timeout=1000):
-                    option = self.page.locator(f"mwc-list-item:text('{period}')").first
-                option.wait_for(state="visible", timeout=DEFAULT_TIMEOUT)
-                if ctx:
-                    self._capture_with_indicator(f"{screenshot_prefix}_period", option)
-                option.click()
-                self.page.wait_for_timeout(300)
+        period_select = time_input.locator("ha-select").first
+        current_period = period_select.evaluate("(el) => el.value || el.textContent.trim().split('\\n')[0].trim()")
+        if current_period != period:
+            period_select.click()
+            option = self.page.get_by_role("option", name=period)
+            option.wait_for(state="visible", timeout=DEFAULT_TIMEOUT)
+            if ctx:
+                self._capture_with_indicator(f"{screenshot_prefix}_period", option)
+            option.click()
+            self.page.wait_for_timeout(300)
 
         # Fill hour
-        if hour_field.is_visible(timeout=1000):
-            hour_field.click()
-            hour_field.fill(str(hour_12))
-            self.page.wait_for_timeout(200)
-            if ctx:
-                self._capture_with_indicator(f"{screenshot_prefix}_hour", hour_field)
+        hour_field.click()
+        hour_field.fill(str(hour_12))
+        self.page.wait_for_timeout(200)
+        if ctx:
+            self._capture_with_indicator(f"{screenshot_prefix}_hour", hour_field)
 
         # Fill minute
-        if minute_field.is_visible(timeout=1000):
-            minute_field.click()
-            minute_field.fill(f"{minute:02d}")
-            self.page.wait_for_timeout(200)
-            if ctx:
-                self._capture_with_indicator(f"{screenshot_prefix}_minute", minute_field)
+        minute_field.click()
+        minute_field.fill(f"{minute:02d}")
+        self.page.wait_for_timeout(200)
+        if ctx:
+            self._capture_with_indicator(f"{screenshot_prefix}_minute", minute_field)
 
     def _set_event_recurrence(self, dialog: Any, recurrence: str) -> None:
         """Set event recurrence in the event dialog.
@@ -982,28 +943,21 @@ class HAPage:
         """
         ctx = ScreenshotContext.current()
 
-        # Look for recurrence dropdown/selector
-        repeat_selector = dialog.locator("ha-select, select").filter(has_text="repeat")
-        if not repeat_selector.is_visible(timeout=1000):
-            repeat_selector = dialog.get_by_role("combobox").filter(has_text="Does not repeat")
-        if not repeat_selector.is_visible(timeout=1000):
-            repeat_selector = dialog.locator("text='Does not repeat'").first
+        repeat_selector = dialog.locator("ha-select").filter(has_text="repeat")
+        repeat_selector.wait_for(state="visible", timeout=DEFAULT_TIMEOUT)
 
-        if repeat_selector.is_visible(timeout=1000):
-            if ctx:
-                self._capture_with_indicator("recurrence_selector", repeat_selector)
-            repeat_selector.click()
+        if ctx:
+            self._capture_with_indicator("recurrence_selector", repeat_selector)
+        repeat_selector.click()
 
-            option = self.page.get_by_role("option", name=recurrence)
-            if not option.is_visible(timeout=1000):
-                option = self.page.locator(f":text('{recurrence}')").first
-            option.wait_for(state="visible", timeout=DEFAULT_TIMEOUT)
-            if ctx:
-                self._capture_with_indicator("recurrence_option", option)
-            option.click()
-            self.page.wait_for_timeout(300)
+        option = self.page.get_by_role("option", name=recurrence)
+        option.wait_for(state="visible", timeout=DEFAULT_TIMEOUT)
+        if ctx:
+            self._capture_with_indicator("recurrence_option", option)
+        option.click()
+        self.page.wait_for_timeout(300)
 
-            if ctx:
-                self._capture("recurrence_set")
+        if ctx:
+            self._capture("recurrence_set")
 
     # endregion

--- a/tests/guides/primitives/ha_page.py
+++ b/tests/guides/primitives/ha_page.py
@@ -570,12 +570,18 @@ class HAPage:
                 self._capture("selected")
         else:
             picker.click()
-            search_input = self.page.get_by_role("textbox", name="Search")
+            combo_selector = "vaadin-combo-box-overlay input, ha-combo-box input[type='search']"
+            search_input = self.page.locator(combo_selector).first
+            if not search_input.is_visible(timeout=1000):
+                search_input = self.page.get_by_role("textbox", name="Search")
             search_input.wait_for(state="visible", timeout=DEFAULT_TIMEOUT)
             search_input.fill(search_term)
-            result_item = self.page.locator(f":text('{entity_name}')").first
+            result_item = self.page.locator(f"ha-combo-box-item:has-text('{entity_name}')").first
+            if not result_item.is_visible(timeout=1000):
+                result_item = self.page.locator(f":text('{entity_name}')").first
             result_item.wait_for(state="visible", timeout=SEARCH_TIMEOUT)
             result_item.click(timeout=DEFAULT_TIMEOUT)
+            self.page.wait_for_timeout(500)
 
     # endregion
 

--- a/tests/guides/primitives/ha_page.py
+++ b/tests/guides/primitives/ha_page.py
@@ -229,7 +229,7 @@ class HAPage:
         """
         ctx = ScreenshotContext.current()
 
-        button = self.page.get_by_role("button", name=name)
+        button = self.page.get_by_role("button", name=name, exact=True)
         button.wait_for(state="visible", timeout=DEFAULT_TIMEOUT)
 
         if ctx:
@@ -240,6 +240,7 @@ class HAPage:
                 self.page.wait_for_load_state("domcontentloaded")
         else:
             button.click(timeout=DEFAULT_TIMEOUT)
+            self.page.wait_for_load_state("domcontentloaded")
 
     def fill_textbox(self, name: str, value: str) -> None:
         """Fill a textbox by accessible name."""
@@ -500,6 +501,84 @@ class HAPage:
 
     # endregion
 
+    # region: Entity Pickers (standalone EntitySelector fields)
+
+    def select_entity(
+        self,
+        field_label: str,
+        search_term: str,
+        entity_name: str,
+    ) -> None:
+        """Select an entity from a standalone EntitySelector field.
+
+        EntitySelector fields render within shadow DOM of ha-form elements.
+        Clicking the ha-combo-box-item trigger opens an inline dropdown
+        with a search box and entity list (not a dialog).
+        """
+        label = self.page.locator(f"text='{field_label}'").first
+        label.wait_for(state="visible", timeout=DEFAULT_TIMEOUT)
+
+        # Find the ha-combo-box-item nearest to this label by bounding box
+        all_pickers = self.page.locator("ha-combo-box-item")
+        label_box = label.bounding_box()
+        picker = None
+
+        if label_box:
+            count = all_pickers.count()
+            best_y_diff = float("inf")
+            for i in range(count):
+                item = all_pickers.nth(i)
+                item_box = item.bounding_box()
+                if item_box and item_box["y"] >= label_box["y"]:
+                    y_diff = item_box["y"] - label_box["y"]
+                    if y_diff < best_y_diff:
+                        best_y_diff = y_diff
+                        picker = item
+
+        if picker is None:
+            msg = f"Could not find entity picker for '{field_label}'"
+            raise RuntimeError(msg)
+
+        ctx = ScreenshotContext.current()
+        if ctx:
+            with ctx.scope(f"select_entity_{field_label}"):
+                self._scroll_and_capture(picker)
+                self._capture_with_indicator("picker", picker)
+
+                picker.click()
+
+                # Entity picker opens an inline dropdown with a search box
+                combo_selector = "vaadin-combo-box-overlay input, ha-combo-box input[type='search']"
+                search_input = self.page.locator(combo_selector).first
+                if not search_input.is_visible(timeout=1000):
+                    # Fallback: find the search textbox that appeared
+                    search_input = self.page.get_by_role("textbox", name="Search")
+                search_input.wait_for(state="visible", timeout=DEFAULT_TIMEOUT)
+                self._capture_with_indicator("search_box", search_input)
+
+                search_input.fill(search_term)
+
+                result_item = self.page.locator(f"ha-combo-box-item:has-text('{entity_name}')").first
+                if not result_item.is_visible(timeout=1000):
+                    result_item = self.page.locator(f":text('{entity_name}')").first
+                result_item.wait_for(state="visible", timeout=SEARCH_TIMEOUT)
+                self._capture("search_results")
+                self._capture_with_indicator("select", result_item)
+
+                result_item.click(timeout=DEFAULT_TIMEOUT)
+                self.page.wait_for_timeout(500)
+                self._capture("selected")
+        else:
+            picker.click()
+            search_input = self.page.get_by_role("textbox", name="Search")
+            search_input.wait_for(state="visible", timeout=DEFAULT_TIMEOUT)
+            search_input.fill(search_term)
+            result_item = self.page.locator(f":text('{entity_name}')").first
+            result_item.wait_for(state="visible", timeout=SEARCH_TIMEOUT)
+            result_item.click(timeout=DEFAULT_TIMEOUT)
+
+    # endregion
+
     # region: Dialogs
 
     def close_element_dialog(self) -> None:
@@ -522,6 +601,7 @@ class HAPage:
         else:
             button.click(timeout=DEFAULT_TIMEOUT)
             button.wait_for(state="hidden", timeout=DEFAULT_TIMEOUT)
+            self.page.wait_for_timeout(500)
 
         _LOGGER.info("Dialog closed successfully")
 
@@ -548,6 +628,7 @@ class HAPage:
         else:
             button.click(timeout=DEFAULT_TIMEOUT)
             button.wait_for(state="hidden", timeout=DEFAULT_TIMEOUT)
+            self.page.wait_for_timeout(500)
 
         _LOGGER.info("Success dialog closed")
 
@@ -560,7 +641,7 @@ class HAPage:
         match once the dialog has finished its internal transition.
         """
         dialog = self.page.locator("ha-dialog[open]").filter(has_text=title)
-        dialog.wait_for(state="attached", timeout=DEFAULT_TIMEOUT)
+        dialog.wait_for(state="attached", timeout=SEARCH_TIMEOUT)
         self.page.wait_for_load_state("domcontentloaded")
         self._wait_for_stable_layout(dialog)
         self._capture("dialog_opened")
@@ -641,9 +722,15 @@ class HAPage:
         """)
 
     def click_add_integration(self) -> None:
-        """Click the Add integration button."""
-        add_btn = self.page.locator("ha-button").get_by_role("button", name="Add integration")
-        add_btn.wait_for(state="visible", timeout=DEFAULT_TIMEOUT)
+        """Click the Add integration button.
+
+        The button may be rendered as ha-button or ha-fab depending on
+        context. Try ha-fab first (integrations list), then ha-button.
+        """
+        add_btn = self.page.locator("ha-fab").get_by_role("button", name="Add integration")
+        if not add_btn.is_visible(timeout=1000):
+            add_btn = self.page.locator("ha-button").get_by_role("button", name="Add integration")
+        add_btn.wait_for(state="visible", timeout=SEARCH_TIMEOUT)
 
         ctx = ScreenshotContext.current()
         if ctx:
@@ -653,5 +740,264 @@ class HAPage:
                 add_btn.click()
         else:
             add_btn.click()
+
+    # endregion
+
+    # region: Calendar
+
+    def navigate_to_calendar(self) -> None:
+        """Navigate to Calendar page via sidebar."""
+        ctx = ScreenshotContext.current()
+        calendar_link = self.page.get_by_text("Calendar", exact=True)
+        calendar_link.wait_for(state="visible", timeout=DEFAULT_TIMEOUT)
+
+        if ctx:
+            with ctx.scope("navigate_calendar"):
+                self._capture_with_indicator("sidebar", calendar_link)
+                calendar_link.click()
+                self.page.wait_for_load_state("networkidle")
+                self._capture("calendar_page")
+        else:
+            calendar_link.click()
+            self.page.wait_for_load_state("networkidle")
+
+    def create_calendar_event(
+        self,
+        *,
+        title: str,
+        location: str | None = None,
+        start_time: str | None = None,
+        end_time: str | None = None,
+        recurrence: str | None = None,
+    ) -> None:
+        """Create a calendar event using the HA calendar UI.
+
+        Opens the event creation dialog, fills in details, and saves.
+        Assumes we're already on the Calendar page.
+
+        Args:
+            title: Event title/summary.
+            location: Event location (optional).
+            start_time: Start time in HH:MM format (optional).
+            end_time: End time in HH:MM format (optional).
+            recurrence: Recurrence rule label (e.g., "Weekly") or None.
+
+        """
+        ctx = ScreenshotContext.current()
+
+        # Click the add event FAB
+        add_btn = self.page.locator("ha-fab, ha-assist-chip").filter(has_text="event").first
+        if not add_btn.is_visible(timeout=1000):
+            # Try the material FAB button
+            add_btn = self.page.get_by_role("button", name="event")
+        add_btn.wait_for(state="visible", timeout=DEFAULT_TIMEOUT)
+
+        if ctx:
+            with ctx.scope("create_event"):
+                self._capture_with_indicator("add_button", add_btn)
+                add_btn.click()
+                self.page.wait_for_load_state("domcontentloaded")
+
+                # Wait for the event dialog
+                dialog = self.page.locator("ha-dialog[open]")
+                dialog.wait_for(state="attached", timeout=DEFAULT_TIMEOUT)
+                self._wait_for_stable_layout(dialog)
+                self._capture("event_dialog")
+
+                # Fill title
+                title_input = dialog.get_by_role("textbox", name="Title")
+                if not title_input.is_visible(timeout=1000):
+                    title_input = dialog.get_by_role("textbox").first
+                title_input.wait_for(state="visible", timeout=DEFAULT_TIMEOUT)
+                self._capture_with_indicator("title_field", title_input)
+                title_input.fill(title)
+                self._capture("title_filled")
+
+                if location:
+                    location_input = dialog.get_by_role("textbox", name="Location")
+                    location_input.wait_for(state="visible", timeout=DEFAULT_TIMEOUT)
+                    self._capture_with_indicator("location_field", location_input)
+                    location_input.fill(location)
+                    self._capture("location_filled")
+
+                self._fill_event_times(dialog, start_time, end_time)
+
+                if recurrence:
+                    self._set_event_recurrence(dialog, recurrence)
+
+                # Save the event
+                save_btn = dialog.locator("mwc-button[slot='primaryAction'], ha-button[slot='primaryAction']").first
+                if not save_btn.is_visible(timeout=1000):
+                    save_btn = dialog.get_by_text("Add event").last
+                # Use the inner button for proper border-radius highlighting
+                inner_btn = save_btn.locator("button").first
+                if inner_btn.is_visible(timeout=500):
+                    self._scroll_into_view(inner_btn)
+                    self._capture_with_indicator("save_button", inner_btn)
+                else:
+                    self._scroll_into_view(save_btn)
+                    self._capture_with_indicator("save_button", save_btn)
+                save_btn.click()
+                dialog.wait_for(state="hidden", timeout=SEARCH_TIMEOUT)
+                self.page.wait_for_timeout(500)
+                self._capture("event_saved")
+        else:
+            add_btn.click()
+            dialog = self.page.locator("ha-dialog[open]")
+            dialog.wait_for(state="attached", timeout=DEFAULT_TIMEOUT)
+            title_input = dialog.get_by_role("textbox", name="Title")
+            if not title_input.is_visible(timeout=1000):
+                title_input = dialog.get_by_role("textbox").first
+            title_input.fill(title)
+            if location:
+                location_input = dialog.get_by_role("textbox", name="Location")
+                location_input.fill(location)
+            self._fill_event_times(dialog, start_time, end_time)
+            if recurrence:
+                self._set_event_recurrence(dialog, recurrence)
+            save_btn = dialog.locator("mwc-button[slot='primaryAction'], ha-button[slot='primaryAction']").first
+            if not save_btn.is_visible(timeout=1000):
+                save_btn = dialog.get_by_text("Add event").last
+            save_btn.click()
+            dialog.wait_for(state="hidden", timeout=SEARCH_TIMEOUT)
+
+    def _fill_event_times(
+        self,
+        dialog: Any,
+        start_time: str | None,
+        end_time: str | None,
+    ) -> None:
+        """Fill start and end times in the event dialog.
+
+        HA's event dialog defaults to all-day events. We need to
+        uncheck the all-day toggle to reveal time fields, then fill
+        the hour, minute, and AM/PM fields by clicking into them.
+
+        Times are specified in 24-hour format (e.g. "08:00", "17:30").
+        """
+        ctx = ScreenshotContext.current()
+
+        # Toggle off all-day if we're setting specific times
+        if start_time or end_time:
+            all_day_toggle = dialog.locator("ha-formfield").filter(has_text="All day")
+            if not all_day_toggle.is_visible(timeout=500):
+                all_day_toggle = dialog.locator("label").filter(has_text="All day")
+            if all_day_toggle.is_visible(timeout=1000):
+                # Check if the toggle is currently ON by inspecting the switch state
+                switch = all_day_toggle.locator("ha-switch")
+                is_checked = switch.evaluate("(el) => el.checked === true") if switch.is_visible(timeout=500) else False
+                if is_checked:
+                    if ctx:
+                        self._capture_with_indicator("all_day_toggle", all_day_toggle)
+                    all_day_toggle.click()
+                    self.page.wait_for_timeout(500)
+
+        time_inputs = dialog.locator("ha-time-input")
+
+        if start_time and time_inputs.count() >= 1:
+            self._fill_single_time(time_inputs.first, start_time, "start_time")
+
+        if end_time and time_inputs.count() >= 2:
+            self._fill_single_time(time_inputs.nth(1), end_time, "end_time")
+
+    def _fill_single_time(
+        self,
+        time_input: Any,
+        time_value: str,
+        screenshot_prefix: str,
+    ) -> None:
+        """Fill a single ha-time-input by clicking into hh/mm fields and setting AM/PM.
+
+        Args:
+            time_input: The ha-time-input locator.
+            time_value: Time in 24-hour format (e.g. "08:00", "17:30").
+            screenshot_prefix: Name prefix for screenshots.
+
+        """
+        ctx = ScreenshotContext.current()
+        hour_24, minute = (int(p) for p in time_value.split(":"))
+
+        # Convert 24h to 12h format
+        if hour_24 == 0:
+            hour_12, period = 12, "AM"
+        elif hour_24 < 12:
+            hour_12, period = hour_24, "AM"
+        elif hour_24 == 12:
+            hour_12, period = 12, "PM"
+        else:
+            hour_12, period = hour_24 - 12, "PM"
+
+        # HA's ha-time-input renders input fields inside shadow DOM.
+        hour_field = time_input.locator("input").first
+        minute_field = time_input.locator("input").nth(1)
+
+        # Set AM/PM first to avoid HA auto-adjusting end time
+        # when the period changes mid-edit.
+        period_select = time_input.locator("ha-select, select, [role='listbox']").first
+        if not period_select.is_visible(timeout=500):
+            period_select = time_input.locator("mwc-select").first
+        if period_select.is_visible(timeout=500):
+            # Check current period by reading the selected value attribute
+            current_period = period_select.evaluate("(el) => el.value || el.textContent.trim().split('\\n')[0].trim()")
+            if current_period != period:
+                period_select.click()
+                option = self.page.get_by_role("option", name=period)
+                if not option.is_visible(timeout=1000):
+                    option = self.page.locator(f"mwc-list-item:text('{period}')").first
+                option.wait_for(state="visible", timeout=DEFAULT_TIMEOUT)
+                if ctx:
+                    self._capture_with_indicator(f"{screenshot_prefix}_period", option)
+                option.click()
+                self.page.wait_for_timeout(300)
+
+        # Fill hour
+        if hour_field.is_visible(timeout=1000):
+            hour_field.click()
+            hour_field.fill(str(hour_12))
+            self.page.wait_for_timeout(200)
+            if ctx:
+                self._capture_with_indicator(f"{screenshot_prefix}_hour", hour_field)
+
+        # Fill minute
+        if minute_field.is_visible(timeout=1000):
+            minute_field.click()
+            minute_field.fill(f"{minute:02d}")
+            self.page.wait_for_timeout(200)
+            if ctx:
+                self._capture_with_indicator(f"{screenshot_prefix}_minute", minute_field)
+
+    def _set_event_recurrence(self, dialog: Any, recurrence: str) -> None:
+        """Set event recurrence in the event dialog.
+
+        Args:
+            dialog: The event dialog locator.
+            recurrence: The recurrence label (e.g., "Weekly").
+
+        """
+        ctx = ScreenshotContext.current()
+
+        # Look for recurrence dropdown/selector
+        repeat_selector = dialog.locator("ha-select, select").filter(has_text="repeat")
+        if not repeat_selector.is_visible(timeout=1000):
+            repeat_selector = dialog.get_by_role("combobox").filter(has_text="Does not repeat")
+        if not repeat_selector.is_visible(timeout=1000):
+            repeat_selector = dialog.locator("text='Does not repeat'").first
+
+        if repeat_selector.is_visible(timeout=1000):
+            if ctx:
+                self._capture_with_indicator("recurrence_selector", repeat_selector)
+            repeat_selector.click()
+
+            option = self.page.get_by_role("option", name=recurrence)
+            if not option.is_visible(timeout=1000):
+                option = self.page.locator(f":text('{recurrence}')").first
+            option.wait_for(state="visible", timeout=DEFAULT_TIMEOUT)
+            if ctx:
+                self._capture_with_indicator("recurrence_option", option)
+            option.click()
+            self.page.wait_for_timeout(300)
+
+            if ctx:
+                self._capture("recurrence_set")
 
     # endregion

--- a/tests/guides/test_guides.py
+++ b/tests/guides/test_guides.py
@@ -25,8 +25,8 @@ from tools.guide_runner import (
     INPUTS_FILE,
     BlockResult,
     GuideManifest,
-    compute_page_hash,
     extract_guide_blocks,
+    get_page_hash,
     output_dir_for_guide,
     run_blocks_for_mode,
 )
@@ -81,16 +81,17 @@ def test_guide(guide_md: Path, dark_mode: bool) -> None:
     # Only write the manifest from the light mode run to avoid
     # the dark mode pass overwriting it with potentially different data.
     if not dark_mode:
+        capturing_blocks = [b for b in blocks if b.captures]
         block_results = [
             BlockResult(
                 index=block.index,
                 content_hash=block.content_hash,
                 screenshots=screenshots_per_block[i],
             )
-            for i, block in enumerate(blocks)
+            for i, block in enumerate(capturing_blocks)
         ]
         manifest = GuideManifest(
-            page_hash=compute_page_hash(blocks),
+            page_hash=get_page_hash(blocks),
             viewport={"width": 1280, "height": 800},
             blocks=block_results,
         )

--- a/tools/guide_fence.py
+++ b/tools/guide_fence.py
@@ -18,17 +18,19 @@ providing visual continuity between slideshows.
 
 from __future__ import annotations
 
-import hashlib
 import json
 import logging
 from pathlib import Path
 from xml.sax.saxutils import escape
+
+from tools.guide_hashing import compute_content_hash, compute_page_hash, extract_sources
 
 _LOGGER = logging.getLogger(__name__)
 
 _DOCS_DIR = Path(__file__).parent.parent / "docs"
 
 _manifest_cache: dict[str, dict[str, object]] | None = None
+_manifest_mtimes: dict[Path, float] = {}
 
 
 def _load_manifests() -> dict[str, dict[str, object]]:
@@ -39,6 +41,7 @@ def _load_manifests() -> dict[str, dict[str, object]]:
     ``_viewport`` — the screenshot viewport dimensions from the manifest.
     """
     index: dict[str, dict[str, object]] = {}
+    _manifest_mtimes.clear()
 
     for manifest_path in _DOCS_DIR.rglob("manifest.json"):
         try:
@@ -47,6 +50,8 @@ def _load_manifests() -> dict[str, dict[str, object]]:
         except (json.JSONDecodeError, OSError):
             _LOGGER.debug("Skipping invalid manifest: %s", manifest_path)
             continue
+
+        _manifest_mtimes[manifest_path] = manifest_path.stat().st_mtime
 
         viewport = data.get("viewport", {"width": 1280, "height": 800})
         blocks = data.get("blocks", [])
@@ -68,7 +73,7 @@ def _load_manifests() -> dict[str, dict[str, object]]:
             content_hash = block["content_hash"]
             if content_hash in index:
                 _LOGGER.warning(
-                    "Duplicate guide block hash %s in %s (already seen in another manifest)",
+                    "Duplicate guide block hash %s in %s",
                     content_hash,
                     manifest_path,
                 )
@@ -78,12 +83,43 @@ def _load_manifests() -> dict[str, dict[str, object]]:
     return index
 
 
-def _find_block(source: str) -> dict[str, object] | None:
+def _manifests_changed() -> bool:
+    """Check whether any manifest file has been added, removed, or modified."""
+    current_paths = set(_DOCS_DIR.rglob("manifest.json"))
+    cached_paths = set(_manifest_mtimes)
+
+    if current_paths != cached_paths:
+        return True
+
+    return any(p.stat().st_mtime != _manifest_mtimes[p] for p in current_paths if p.exists())
+
+
+def _get_page_hash(md: object) -> str:
+    """Get or compute the page hash for this Markdown processor instance.
+
+    Each page gets a fresh ``Markdown`` instance. On first call, the
+    page hash is computed from all guide block sources in ``md.lines``
+    and cached on the instance for subsequent blocks on the same page.
+    """
+    cached: str | None = getattr(md, "_guide_page_hash", None)
+    if cached is not None:
+        return cached
+
+    lines: list[str] = getattr(md, "lines", [])
+    markdown = "\n".join(lines)
+    sources = extract_sources(markdown)
+    page_hash = compute_page_hash(sources)
+
+    md._guide_page_hash = page_hash  # type: ignore[attr-defined]  # noqa: SLF001
+    return page_hash
+
+
+def _find_block(source: str, page_hash: str) -> dict[str, object] | None:
     """Find the manifest block matching this source code by content hash."""
     global _manifest_cache  # noqa: PLW0603
-    if _manifest_cache is None:
+    if _manifest_cache is None or _manifests_changed():
         _manifest_cache = _load_manifests()
-    content_hash = hashlib.sha256(source.strip().encode()).hexdigest()[:16]
+    content_hash = compute_content_hash(page_hash, source)
     return _manifest_cache.get(content_hash)
 
 
@@ -215,9 +251,26 @@ def format_guide(
         HTML string to replace the fenced block.
 
     """
-    block = _find_block(source)
+    page_hash = _get_page_hash(_md)
+    block = _find_block(source, page_hash)
 
     if block is None:
         return _render_placeholder(source, "Run guide tests to generate screenshots")
 
     return _render_slideshow(block, source)
+
+
+def format_guide_setup(
+    _source: str,
+    _language: str,
+    _class_name: str,
+    _options: dict[str, str],
+    _md: object,
+    **_kwargs: object,
+) -> str:
+    """Format a ```guide-setup fence block as hidden content.
+
+    Setup blocks run prerequisite guide steps during test execution
+    but are not rendered in the documentation output.
+    """
+    return ""

--- a/tools/guide_fence.py
+++ b/tools/guide_fence.py
@@ -91,10 +91,7 @@ def _manifests_changed() -> bool:
     detected until the cache is next cleared — this is fine for mkdocs
     build where all manifests exist at build start.
     """
-    return any(
-        not p.exists() or p.stat().st_mtime != mtime
-        for p, mtime in _manifest_mtimes.items()
-    )
+    return any(not p.exists() or p.stat().st_mtime != mtime for p, mtime in _manifest_mtimes.items())
 
 
 def _get_page_hash(md: object) -> str:

--- a/tools/guide_fence.py
+++ b/tools/guide_fence.py
@@ -84,14 +84,17 @@ def _load_manifests() -> dict[str, dict[str, object]]:
 
 
 def _manifests_changed() -> bool:
-    """Check whether any manifest file has been added, removed, or modified."""
-    current_paths = set(_DOCS_DIR.rglob("manifest.json"))
-    cached_paths = set(_manifest_mtimes)
+    """Check whether any cached manifest file has been modified.
 
-    if current_paths != cached_paths:
-        return True
-
-    return any(p.stat().st_mtime != _manifest_mtimes[p] for p in current_paths if p.exists())
+    Only checks mtimes of previously discovered manifests (no filesystem
+    traversal). New manifests added after the initial scan won't be
+    detected until the cache is next cleared — this is fine for mkdocs
+    build where all manifests exist at build start.
+    """
+    return any(
+        not p.exists() or p.stat().st_mtime != mtime
+        for p, mtime in _manifest_mtimes.items()
+    )
 
 
 def _get_page_hash(md: object) -> str:

--- a/tools/guide_hashing.py
+++ b/tools/guide_hashing.py
@@ -1,0 +1,49 @@
+"""Shared hashing utilities for guide blocks.
+
+Used by both the guide runner (to write manifests) and the guide fence
+formatter (to look up blocks). Keeping the algorithms in one place
+ensures the hashes always match.
+
+Content hashes are page-scoped: ``sha256(page_hash + ":" + source)``.
+This ensures identical code blocks (e.g., ``verify_setup(page)``) on
+different pages produce different hashes, avoiding cross-page collisions.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+
+_GUIDE_BLOCK_RE = re.compile(
+    r"^```guide(?:-setup)?\s*\n(?P<source>.*?)^```\s*$",
+    re.MULTILINE | re.DOTALL,
+)
+
+
+def compute_page_hash(sources: list[str]) -> str:
+    """Compute a combined hash from all guide block sources on a page.
+
+    Includes both setup and non-setup blocks since changes to either
+    affect the screenshots.
+    """
+    combined = "\n---\n".join(sources)
+    return hashlib.sha256(combined.encode()).hexdigest()[:16]
+
+
+def compute_content_hash(page_hash: str, source: str) -> str:
+    """Compute a page-scoped content hash for a single guide block.
+
+    Including ``page_hash`` ensures identical source code on different
+    pages (e.g., ``verify_setup(page)``) produces different hashes.
+    """
+    combined = f"{page_hash}:{source.strip()}"
+    return hashlib.sha256(combined.encode()).hexdigest()[:16]
+
+
+def extract_sources(markdown: str) -> list[str]:
+    """Extract guide block sources from raw markdown text.
+
+    Returns sources in document order, including both setup and
+    non-setup blocks.
+    """
+    return [m.group("source") for m in _GUIDE_BLOCK_RE.finditer(markdown)]

--- a/tools/guide_runner.py
+++ b/tools/guide_runner.py
@@ -14,7 +14,6 @@ Usage:
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-import hashlib
 import json
 import logging
 from pathlib import Path
@@ -37,9 +36,11 @@ from tests.guides.primitives import (
     add_node,
     add_solar,
     login,
+    pause_screenshots,
     screenshot_context,
     verify_setup,
 )
+from tools.guide_hashing import compute_content_hash, compute_page_hash, extract_sources
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -48,9 +49,9 @@ PROJECT_ROOT = Path(__file__).parent.parent
 DOCS_DIR = PROJECT_ROOT / "docs"
 INPUTS_FILE = PROJECT_ROOT / "tests" / "scenarios" / "scenario1" / "inputs.json"
 
-# Regex to extract ```guide blocks from markdown
+# Regex to extract ```guide and ```guide-setup blocks from markdown
 _GUIDE_BLOCK_RE = re.compile(
-    r"^```guide\s*\n(.*?)^```\s*$",
+    r"^```guide(?P<setup>-setup)?\s*\n(?P<source>.*?)^```\s*$",
     re.MULTILINE | re.DOTALL,
 )
 
@@ -63,12 +64,14 @@ class GuideBlock:
         index: Zero-based position of this block in the page.
         source: The Python source code inside the fenced block.
         content_hash: SHA-256 hex digest of the source code.
+        captures: Whether this block captures screenshots (False for guide-setup).
 
     """
 
     index: int
     source: str
     content_hash: str
+    captures: bool = True
 
 
 @dataclass
@@ -144,22 +147,58 @@ class GuideManifest:
 
 
 def extract_guide_blocks(markdown: str) -> list[GuideBlock]:
-    """Extract all ```guide fenced code blocks from markdown text.
+    """Extract all ```guide and ```guide-setup fenced code blocks from markdown text.
 
-    Returns blocks in document order with their content hashes.
+    Returns blocks in document order with page-scoped content hashes.
+    Setup blocks have captures=False and are excluded from manifests.
     """
+    # First pass: extract sources to compute page hash
+    sources = extract_sources(markdown)
+    page_hash = compute_page_hash(sources)
+
+    # Second pass: build blocks with page-scoped content hashes
     blocks: list[GuideBlock] = []
     for i, match in enumerate(_GUIDE_BLOCK_RE.finditer(markdown)):
-        source = match.group(1)
-        content_hash = hashlib.sha256(source.strip().encode()).hexdigest()[:16]
-        blocks.append(GuideBlock(index=i, source=source, content_hash=content_hash))
+        source = match.group("source")
+        is_setup = match.group("setup") is not None
+        content_hash = compute_content_hash(page_hash, source)
+        blocks.append(GuideBlock(index=i, source=source, content_hash=content_hash, captures=not is_setup))
     return blocks
 
 
-def compute_page_hash(blocks: list[GuideBlock]) -> str:
-    """Compute a combined hash of all block sources for cache invalidation."""
-    combined = "\n---\n".join(b.source for b in blocks)
-    return hashlib.sha256(combined.encode()).hexdigest()[:16]
+def get_page_hash(blocks: list[GuideBlock]) -> str:
+    """Compute a combined hash of all block sources for cache invalidation.
+
+    Includes both setup and guide blocks since changes to either
+    should invalidate the cache.
+    """
+    return compute_page_hash([b.source for b in blocks])
+
+
+def _run_guide_silently(page: HAPage, guide_name: str) -> None:
+    """Execute all guide blocks from another walkthrough without screenshots.
+
+    Loads the referenced guide's markdown, extracts its guide blocks
+    (excluding any guide-setup blocks to avoid recursive prerequisites),
+    and executes them in a fresh namespace sharing the same page.
+
+    Wraps execution in pause_screenshots() so that even if called from
+    a capturing guide block, the prerequisite's actions don't produce
+    screenshots attributed to the caller.
+    """
+    guide_path = DOCS_DIR / "walkthroughs" / f"{guide_name}.md"
+    if not guide_path.exists():
+        msg = f"Prerequisite guide not found: {guide_path}"
+        raise FileNotFoundError(msg)
+
+    markdown = guide_path.read_text(encoding="utf-8")
+    ref_blocks = extract_guide_blocks(markdown)
+
+    namespace = build_exec_namespace(page)
+    with pause_screenshots():
+        for block in ref_blocks:
+            if block.captures:
+                exec(compile(block.source, f"<{guide_name} block {block.index}>", "exec"), namespace)  # noqa: S102
 
 
 def build_exec_namespace(page: HAPage) -> dict[str, object]:
@@ -179,6 +218,8 @@ def build_exec_namespace(page: HAPage) -> dict[str, object]:
         "add_load": add_load,
         "add_node": add_node,
         "verify_setup": verify_setup,
+        # Guide chaining
+        "run_guide": lambda guide_name: _run_guide_silently(page, guide_name),
     }
 
 
@@ -231,6 +272,12 @@ def run_blocks_for_mode(
                 per_block: list[list[str]] = []
 
                 for block in blocks:
+                    if not block.captures:
+                        # Setup blocks run without screenshot capture
+                        with pause_screenshots():
+                            exec(compile(block.source, f"<guide-setup block {block.index}>", "exec"), namespace)  # noqa: S102
+                        continue
+
                     # Record screenshots before this block
                     before_count = len(ctx.screenshots)
 
@@ -281,7 +328,7 @@ def run_guide_from_markdown(
         _LOGGER.warning("No guide blocks found in %s", markdown_path)
         return GuideManifest(page_hash="empty", viewport={"width": 1280, "height": 800}, blocks=[])
 
-    page_hash = compute_page_hash(blocks)
+    page_hash = get_page_hash(blocks)
     output_dir = output_dir_for_guide(markdown_path)
     manifest_path = output_dir / "manifest.json"
 
@@ -317,14 +364,15 @@ def run_guide_from_markdown(
             msg = f"Block {i} screenshot mismatch between light and dark modes: light={light_names}, dark={dark_names}"
             raise RuntimeError(msg)
 
-    # Build manifest (both modes produce identical filenames)
+    # Build manifest from capturing blocks only (setup blocks are excluded)
+    capturing_blocks = [b for b in blocks if b.captures]
     block_results = [
         BlockResult(
             index=block.index,
             content_hash=block.content_hash,
             screenshots=light_results[i],
         )
-        for i, block in enumerate(blocks)
+        for i, block in enumerate(capturing_blocks)
     ]
 
     manifest = GuideManifest(page_hash=page_hash, viewport=viewport, blocks=block_results)


### PR DESCRIPTION
## Summary

Extracts generic guide tooling improvements from #361 (EV element) into a standalone PR.

## Changes

### Guide block infrastructure
- **`guide-setup` fenced blocks**: New block type for prerequisite setup that runs without capturing screenshots
- **Page-scoped content hashing** (`tools/guide_hashing.py`): Shared hashing utilities for guide blocks, replacing per-block SHA-256 with page-scoped hashes for reliable cache invalidation when any block on a page changes
- **Guide chaining** (`run_guide()`): Execute prerequisite walkthroughs silently before running the current guide

### Screenshot control
- **`pause_screenshots()` context manager**: Suppress screenshot capture during prerequisite guide execution or setup blocks

### HA page reliability improvements
- `click_button()` with `exact=True` matching
- `domcontentloaded` wait states for faster navigation
- Dialog timeout improvements
- `click_add_integration()` ha-fab fallback
- `select_entity()` method for entity picker interactions
- Calendar UI helpers (`navigate_to_calendar`, `create_calendar_event`, time filling)

### Infrastructure
- Register `guide-setup` fence formatter in `mkdocs.yml`
- Setup `calendar` and `local_calendar` components in HA test runner
- Update `test_guides.py` to use page-scoped hashing and filter capturing blocks

## Relation to #361

This PR contains the generic guide tooling that #361 (EV element) depends on. After this merges, #361 will be rebased to only contain EV-specific changes.