### PR TITLE
Add Nordpool energy pricing data extractor

### DIFF
--- a/custom_components/haeo/core/data/loader/extractors/__init__.py
+++ b/custom_components/haeo/core/data/loader/extractors/__init__.py
@@ -7,7 +7,17 @@ from typing import NamedTuple
 from custom_components.haeo.core.state import EntityState
 from custom_components.haeo.core.units import DeviceClass, UnitOfMeasurement, convert_to_base_unit
 
-from . import aemo_nem, amber2mqtt, amberelectric, emhass, flow_power, haeo, open_meteo_solar_forecast, solcast_solar
+from . import (
+    aemo_nem,
+    amber2mqtt,
+    amberelectric,
+    emhass,
+    flow_power,
+    haeo,
+    nordpool,
+    open_meteo_solar_forecast,
+    solcast_solar,
+)
 from .utils import EntityMetadata, separate_duplicate_timestamps
 
 # Union of all domain literal types from the extractor modules
@@ -18,6 +28,7 @@ ExtractorFormat = (
     | emhass.Format
     | flow_power.Format
     | haeo.Format
+    | nordpool.Format
     | open_meteo_solar_forecast.Format
     | solcast_solar.Format
 )
@@ -30,6 +41,7 @@ DataExtractor = (
     | type[emhass.Parser]
     | type[flow_power.Parser]
     | type[haeo.Parser]
+    | type[nordpool.Parser]
     | type[open_meteo_solar_forecast.Parser]
     | type[solcast_solar.Parser]
 )
@@ -43,6 +55,7 @@ FORMATS: dict[ExtractorFormat, DataExtractor] = {
     emhass.DOMAIN: emhass.Parser,
     flow_power.DOMAIN: flow_power.Parser,
     haeo.DOMAIN: haeo.Parser,
+    nordpool.DOMAIN: nordpool.Parser,
     open_meteo_solar_forecast.DOMAIN: open_meteo_solar_forecast.Parser,
     solcast_solar.DOMAIN: solcast_solar.Parser,
 }
@@ -77,6 +90,8 @@ def extract(state: EntityState) -> ExtractedData:
         data, unit, device_class = flow_power.Parser.extract(state)
     elif haeo.Parser.detect(state):
         data, unit, device_class = haeo.Parser.extract(state)
+    elif nordpool.Parser.detect(state):
+        data, unit, device_class = nordpool.Parser.extract(state)
     elif open_meteo_solar_forecast.Parser.detect(state):
         data, unit, device_class = open_meteo_solar_forecast.Parser.extract(state)
     elif solcast_solar.Parser.detect(state):

--- a/custom_components/haeo/core/data/loader/extractors/nordpool.py
+++ b/custom_components/haeo/core/data/loader/extractors/nordpool.py
@@ -1,0 +1,118 @@
+"""Nordpool energy pricing forecast parser.
+
+Nordpool provides energy pricing data via the nordpool HACS integration.
+Sensors expose current price as the state value, with forecast data
+in ``raw_today`` and ``raw_tomorrow`` attributes containing start/end
+timestamps and price values.
+
+See: https://github.com/custom-components/nordpool
+"""
+
+from collections.abc import Mapping, Sequence
+import logging
+from typing import Literal, Protocol, TypedDict, TypeGuard
+
+from custom_components.haeo.core.state import EntityState
+from custom_components.haeo.core.units import DeviceClass
+
+from .utils import is_parsable_to_datetime, parse_datetime_to_timestamp
+
+_LOGGER = logging.getLogger(__name__)
+
+Format = Literal["nordpool"]
+DOMAIN: Format = "nordpool"
+
+
+class NordpoolForecastEntry(TypedDict):
+    """Type definition for a Nordpool raw forecast entry."""
+
+    start: str
+    end: str
+    value: float
+
+
+class NordpoolAttributes(TypedDict):
+    """Type definition for Nordpool State attributes."""
+
+    raw_today: Sequence[NordpoolForecastEntry]
+    raw_tomorrow: Sequence[NordpoolForecastEntry]
+    currency: str
+
+
+class NordpoolState(Protocol):
+    """Protocol for a State object with validated Nordpool forecast data."""
+
+    attributes: NordpoolAttributes
+
+
+class Parser:
+    """Parser for Nordpool energy pricing forecast data.
+
+    Nordpool sensors provide pricing in the ``raw_today`` and ``raw_tomorrow``
+    attributes as lists of ``{start, end, value}`` entries with ISO datetime strings.
+    """
+
+    DOMAIN: Format = DOMAIN
+    DEVICE_CLASS: DeviceClass = DeviceClass.MONETARY
+
+    @staticmethod
+    def detect(state: EntityState) -> TypeGuard[NordpoolState]:
+        """Check if data matches Nordpool format and narrow type."""
+        if "raw_today" not in state.attributes:
+            return False
+
+        raw_today = state.attributes["raw_today"]
+        if not (isinstance(raw_today, Sequence) and not isinstance(raw_today, (str, bytes))) or not raw_today:
+            return False
+
+        return all(
+            isinstance(item, Mapping)
+            and "start" in item
+            and "end" in item
+            and "value" in item
+            and isinstance(item["value"], (int, float))
+            and is_parsable_to_datetime(item["start"])
+            and is_parsable_to_datetime(item["end"])
+            for item in raw_today
+        )
+
+    @staticmethod
+    def _unit(state: NordpoolState) -> str:
+        """Derive the unit string from the currency attribute."""
+        currency = state.attributes.get("currency", "EUR")
+        return f"{currency}/kWh"
+
+    @staticmethod
+    def _parse_entries(entries: Sequence[NordpoolForecastEntry]) -> list[tuple[int, float]]:
+        """Parse a list of Nordpool forecast entries into step-function boundary points.
+
+        Each entry produces two points (start, value) and (end, value) to create
+        a step function without linear interpolation between periods.
+        """
+        parsed: list[tuple[int, float]] = []
+        for item in entries:
+            start = parse_datetime_to_timestamp(item["start"])
+            end = parse_datetime_to_timestamp(item["end"])
+            value = item["value"]
+            parsed.append((start, value))
+            parsed.append((end, value))
+        return parsed
+
+    @staticmethod
+    def extract(state: NordpoolState) -> tuple[Sequence[tuple[int, float]], str, DeviceClass]:
+        """Extract forecast data from Nordpool format.
+
+        Combines ``raw_today`` and ``raw_tomorrow`` (when available) into a
+        single time series with step-function boundaries.
+        """
+        parsed = Parser._parse_entries(state.attributes["raw_today"])
+
+        # Include tomorrow's data when available
+        raw_tomorrow = state.attributes.get("raw_tomorrow")
+        if raw_tomorrow:
+            parsed.extend(Parser._parse_entries(raw_tomorrow))
+
+        parsed.sort(key=lambda x: x[0])
+
+        unit = Parser._unit(state)
+        return parsed, unit, Parser.DEVICE_CLASS

--- a/custom_components/haeo/core/data/loader/extractors/nordpool.py
+++ b/custom_components/haeo/core/data/loader/extractors/nordpool.py
@@ -56,13 +56,9 @@ class Parser:
     DEVICE_CLASS: DeviceClass = DeviceClass.MONETARY
 
     @staticmethod
-    def detect(state: EntityState) -> TypeGuard[NordpoolState]:
-        """Check if data matches Nordpool format and narrow type."""
-        if "raw_today" not in state.attributes:
-            return False
-
-        raw_today = state.attributes["raw_today"]
-        if not (isinstance(raw_today, Sequence) and not isinstance(raw_today, (str, bytes))) or not raw_today:
+    def _is_valid_entries(entries: object) -> bool:
+        """Check if entries are a valid non-empty sequence of Nordpool forecast items."""
+        if not (isinstance(entries, Sequence) and not isinstance(entries, (str, bytes))) or not entries:
             return False
 
         return all(
@@ -73,14 +69,32 @@ class Parser:
             and isinstance(item["value"], (int, float))
             and is_parsable_to_datetime(item["start"])
             and is_parsable_to_datetime(item["end"])
-            for item in raw_today
+            for item in entries
         )
+
+    @staticmethod
+    def detect(state: EntityState) -> TypeGuard[NordpoolState]:
+        """Check if data matches Nordpool format and narrow type."""
+        attrs = state.attributes
+        if "raw_today" not in attrs or "raw_tomorrow" not in attrs or "currency" not in attrs:
+            return False
+
+        if not isinstance(attrs["currency"], str):
+            return False
+
+        if not Parser._is_valid_entries(attrs["raw_today"]):
+            return False
+
+        raw_tomorrow = attrs["raw_tomorrow"]
+        if not isinstance(raw_tomorrow, Sequence) or isinstance(raw_tomorrow, (str, bytes)):
+            return False
+
+        return not raw_tomorrow or Parser._is_valid_entries(raw_tomorrow)
 
     @staticmethod
     def _unit(state: NordpoolState) -> str:
         """Derive the unit string from the currency attribute."""
-        currency = state.attributes.get("currency", "EUR")
-        return f"{currency}/kWh"
+        return f"{state.attributes['currency']}/kWh"
 
     @staticmethod
     def _parse_entries(entries: Sequence[NordpoolForecastEntry]) -> list[tuple[int, float]]:
@@ -107,8 +121,7 @@ class Parser:
         """
         parsed = Parser._parse_entries(state.attributes["raw_today"])
 
-        # Include tomorrow's data when available
-        raw_tomorrow = state.attributes.get("raw_tomorrow")
+        raw_tomorrow = state.attributes["raw_tomorrow"]
         if raw_tomorrow:
             parsed.extend(Parser._parse_entries(raw_tomorrow))
 

--- a/custom_components/haeo/core/data/loader/extractors/tests/test_data/sensors/__init__.py
+++ b/custom_components/haeo/core/data/loader/extractors/tests/test_data/sensors/__init__.py
@@ -6,7 +6,7 @@ by parser type for easy access in parameterized tests.
 
 from typing import Any
 
-from . import aemo, amber2mqtt, amberelectric, emhass, flow_power, haeo, open_meteo, solcast
+from . import aemo, amber2mqtt, amberelectric, emhass, flow_power, haeo, nordpool, open_meteo, solcast
 
 # Aggregate all valid sensor configs by parser type
 VALID_SENSORS_BY_PARSER: dict[str, list[dict[str, Any]]] = {
@@ -16,6 +16,7 @@ VALID_SENSORS_BY_PARSER: dict[str, list[dict[str, Any]]] = {
     "emhass": emhass.VALID,
     "flow_power": flow_power.VALID,
     "haeo": haeo.VALID,
+    "nordpool": nordpool.VALID,
     "solcast_solar": solcast.VALID,
     "open_meteo_solar_forecast": open_meteo.VALID,
 }
@@ -28,6 +29,7 @@ INVALID_SENSORS_BY_PARSER: dict[str, list[dict[str, Any]]] = {
     "emhass": emhass.INVALID,
     "flow_power": flow_power.INVALID,
     "haeo": haeo.INVALID,
+    "nordpool": nordpool.INVALID,
     "solcast_solar": solcast.INVALID,
     "open_meteo_solar_forecast": open_meteo.INVALID,
 }

--- a/custom_components/haeo/core/data/loader/extractors/tests/test_data/sensors/nordpool.py
+++ b/custom_components/haeo/core/data/loader/extractors/tests/test_data/sensors/nordpool.py
@@ -100,6 +100,7 @@ INVALID: list[dict[str, Any]] = [
         "state": "0.10",
         "attributes": {
             "currency": "EUR",
+            "raw_tomorrow": [],
             "today": [0.10, 0.08],
         },
         "expected_format": None,
@@ -111,6 +112,7 @@ INVALID: list[dict[str, Any]] = [
         "attributes": {
             "currency": "EUR",
             "raw_today": [],
+            "raw_tomorrow": [],
         },
         "expected_format": None,
         "description": "Nordpool sensor with empty raw_today list",
@@ -121,6 +123,7 @@ INVALID: list[dict[str, Any]] = [
         "attributes": {
             "currency": "EUR",
             "raw_today": "not a list",
+            "raw_tomorrow": [],
         },
         "expected_format": None,
         "description": "Nordpool sensor with raw_today not being a list",
@@ -131,6 +134,7 @@ INVALID: list[dict[str, Any]] = [
         "attributes": {
             "currency": "EUR",
             "raw_today": [{"start": "2025-10-05T00:00:00+02:00", "value": 0.10}],
+            "raw_tomorrow": [],
         },
         "expected_format": None,
         "description": "Nordpool sensor with entry missing end field",
@@ -147,8 +151,92 @@ INVALID: list[dict[str, Any]] = [
                     "value": "not_a_number",
                 },
             ],
+            "raw_tomorrow": [],
         },
         "expected_format": None,
         "description": "Nordpool sensor with non-numeric value",
+    },
+    {
+        "entity_id": "sensor.nordpool_missing_currency",
+        "state": "0.10",
+        "attributes": {
+            "raw_today": [
+                {
+                    "start": "2025-10-05T00:00:00+02:00",
+                    "end": "2025-10-05T01:00:00+02:00",
+                    "value": 0.10,
+                },
+            ],
+            "raw_tomorrow": [],
+        },
+        "expected_format": None,
+        "description": "Nordpool sensor missing currency attribute",
+    },
+    {
+        "entity_id": "sensor.nordpool_non_string_currency",
+        "state": "0.10",
+        "attributes": {
+            "currency": 123,
+            "raw_today": [
+                {
+                    "start": "2025-10-05T00:00:00+02:00",
+                    "end": "2025-10-05T01:00:00+02:00",
+                    "value": 0.10,
+                },
+            ],
+            "raw_tomorrow": [],
+        },
+        "expected_format": None,
+        "description": "Nordpool sensor with non-string currency",
+    },
+    {
+        "entity_id": "sensor.nordpool_missing_raw_tomorrow",
+        "state": "0.10",
+        "attributes": {
+            "currency": "EUR",
+            "raw_today": [
+                {
+                    "start": "2025-10-05T00:00:00+02:00",
+                    "end": "2025-10-05T01:00:00+02:00",
+                    "value": 0.10,
+                },
+            ],
+        },
+        "expected_format": None,
+        "description": "Nordpool sensor missing raw_tomorrow attribute",
+    },
+    {
+        "entity_id": "sensor.nordpool_malformed_raw_tomorrow",
+        "state": "0.10",
+        "attributes": {
+            "currency": "EUR",
+            "raw_today": [
+                {
+                    "start": "2025-10-05T00:00:00+02:00",
+                    "end": "2025-10-05T01:00:00+02:00",
+                    "value": 0.10,
+                },
+            ],
+            "raw_tomorrow": [{"start": "bad", "end": "bad", "value": "not_a_number"}],
+        },
+        "expected_format": None,
+        "description": "Nordpool sensor with malformed raw_tomorrow entries",
+    },
+    {
+        "entity_id": "sensor.nordpool_string_raw_tomorrow",
+        "state": "0.10",
+        "attributes": {
+            "currency": "EUR",
+            "raw_today": [
+                {
+                    "start": "2025-10-05T00:00:00+02:00",
+                    "end": "2025-10-05T01:00:00+02:00",
+                    "value": 0.10,
+                },
+            ],
+            "raw_tomorrow": "not a list",
+        },
+        "expected_format": None,
+        "description": "Nordpool sensor with non-sequence raw_tomorrow",
     },
 ]

--- a/custom_components/haeo/core/data/loader/extractors/tests/test_data/sensors/nordpool.py
+++ b/custom_components/haeo/core/data/loader/extractors/tests/test_data/sensors/nordpool.py
@@ -1,0 +1,154 @@
+"""Test data for Nordpool energy pricing forecast sensors."""
+
+from typing import Any
+
+VALID: list[dict[str, Any]] = [
+    {
+        "entity_id": "sensor.nordpool_kwh_eur",
+        "state": "0.093",
+        "attributes": {
+            "currency": "EUR",
+            "raw_today": [
+                {
+                    "start": "2025-10-05T00:00:00+02:00",
+                    "end": "2025-10-05T01:00:00+02:00",
+                    "value": 0.10,
+                },
+                {
+                    "start": "2025-10-05T01:00:00+02:00",
+                    "end": "2025-10-05T02:00:00+02:00",
+                    "value": 0.08,
+                },
+            ],
+            "raw_tomorrow": [],
+        },
+        "expected_format": "nordpool",
+        "expected_unit": "EUR/kWh",
+        "expected_data": [
+            (1759615200.0, 0.10),
+            (1759618800.0, 0.10),
+            (1759618800.0, 0.08),
+            (1759622400.0, 0.08),
+        ],
+        "description": "Nordpool sensor with two hourly entries",
+    },
+    {
+        "entity_id": "sensor.nordpool_kwh_eur_15min",
+        "state": "0.25",
+        "attributes": {
+            "currency": "EUR",
+            "raw_today": [
+                {
+                    "start": "2025-10-05T00:00:00+02:00",
+                    "end": "2025-10-05T00:15:00+02:00",
+                    "value": 0.25,
+                },
+                {
+                    "start": "2025-10-05T00:15:00+02:00",
+                    "end": "2025-10-05T00:30:00+02:00",
+                    "value": 0.30,
+                },
+            ],
+            "raw_tomorrow": [
+                {
+                    "start": "2025-10-06T00:00:00+02:00",
+                    "end": "2025-10-06T00:15:00+02:00",
+                    "value": 0.12,
+                },
+            ],
+        },
+        "expected_format": "nordpool",
+        "expected_unit": "EUR/kWh",
+        "expected_data": [
+            (1759615200.0, 0.25),
+            (1759616100.0, 0.25),
+            (1759616100.0, 0.30),
+            (1759617000.0, 0.30),
+            (1759701600.0, 0.12),
+            (1759702500.0, 0.12),
+        ],
+        "description": "Nordpool sensor with 15-minute intervals and tomorrow data",
+    },
+    {
+        "entity_id": "sensor.nordpool_kwh_nok",
+        "state": "1.25",
+        "attributes": {
+            "currency": "NOK",
+            "raw_today": [
+                {
+                    "start": "2025-10-05T00:00:00+02:00",
+                    "end": "2025-10-05T01:00:00+02:00",
+                    "value": 1.25,
+                },
+            ],
+            "raw_tomorrow": [],
+        },
+        "expected_format": "nordpool",
+        "expected_unit": "NOK/kWh",
+        "expected_data": [
+            (1759615200.0, 1.25),
+            (1759618800.0, 1.25),
+        ],
+        "description": "Nordpool sensor with NOK currency",
+    },
+]
+
+# Invalid Nordpool sensor configurations
+INVALID: list[dict[str, Any]] = [
+    {
+        "entity_id": "sensor.nordpool_no_raw_today",
+        "state": "0.10",
+        "attributes": {
+            "currency": "EUR",
+            "today": [0.10, 0.08],
+        },
+        "expected_format": None,
+        "description": "Nordpool sensor missing raw_today attribute",
+    },
+    {
+        "entity_id": "sensor.nordpool_empty_raw_today",
+        "state": "0.10",
+        "attributes": {
+            "currency": "EUR",
+            "raw_today": [],
+        },
+        "expected_format": None,
+        "description": "Nordpool sensor with empty raw_today list",
+    },
+    {
+        "entity_id": "sensor.nordpool_bad_raw_today",
+        "state": "0.10",
+        "attributes": {
+            "currency": "EUR",
+            "raw_today": "not a list",
+        },
+        "expected_format": None,
+        "description": "Nordpool sensor with raw_today not being a list",
+    },
+    {
+        "entity_id": "sensor.nordpool_missing_fields",
+        "state": "0.10",
+        "attributes": {
+            "currency": "EUR",
+            "raw_today": [{"start": "2025-10-05T00:00:00+02:00", "value": 0.10}],
+        },
+        "expected_format": None,
+        "description": "Nordpool sensor with entry missing end field",
+    },
+    {
+        "entity_id": "sensor.nordpool_invalid_value",
+        "state": "0.10",
+        "attributes": {
+            "currency": "EUR",
+            "raw_today": [
+                {
+                    "start": "2025-10-05T00:00:00+02:00",
+                    "end": "2025-10-05T01:00:00+02:00",
+                    "value": "not_a_number",
+                },
+            ],
+        },
+        "expected_format": None,
+        "description": "Nordpool sensor with non-numeric value",
+    },
+]

--- a/custom_components/haeo/core/data/loader/extractors/tests/test_forecast_parser.py
+++ b/custom_components/haeo/core/data/loader/extractors/tests/test_forecast_parser.py
@@ -125,6 +125,7 @@ PARSER_MAP: dict[str, extractors.DataExtractor] = {
     extractors.aemo_nem.DOMAIN: extractors.aemo_nem.Parser,
     extractors.flow_power.DOMAIN: extractors.flow_power.Parser,
     extractors.haeo.DOMAIN: extractors.haeo.Parser,
+    extractors.nordpool.DOMAIN: extractors.nordpool.Parser,
     extractors.solcast_solar.DOMAIN: extractors.solcast_solar.Parser,
     extractors.open_meteo_solar_forecast.DOMAIN: extractors.open_meteo_solar_forecast.Parser,
 }

--- a/docs/developer-guide/data-loading.md
+++ b/docs/developer-guide/data-loading.md
@@ -163,6 +163,7 @@ The extractor system ([`extractors/`](https://github.com/hass-energy/haeo/tree/m
 | EMHASS                    | Energy management forecasts  | [`emhass.py`](https://github.com/hass-energy/haeo/blob/main/custom_components/haeo/core/data/loader/extractors/emhass.py)                                       |
 | Flow Power                | Electricity pricing          | [`flow_power.py`](https://github.com/hass-energy/haeo/blob/main/custom_components/haeo/core/data/loader/extractors/flow_power.py)                               |
 | HAEO                      | Chaining HAEO sensor outputs | [`haeo.py`](https://github.com/hass-energy/haeo/blob/main/custom_components/haeo/core/data/loader/extractors/haeo.py)                                           |
+| Nordpool                  | Electricity pricing          | [`nordpool.py`](https://github.com/hass-energy/haeo/blob/main/custom_components/haeo/core/data/loader/extractors/nordpool.py)                                   |
 | Solcast Solar             | Solar forecasting            | [`solcast_solar.py`](https://github.com/hass-energy/haeo/blob/main/custom_components/haeo/core/data/loader/extractors/solcast_solar.py)                         |
 | Open-Meteo Solar Forecast | Solar forecasting            | [`open_meteo_solar_forecast.py`](https://github.com/hass-energy/haeo/blob/main/custom_components/haeo/core/data/loader/extractors/open_meteo_solar_forecast.py) |
 

--- a/docs/user-guide/forecasts-and-sensors.md
+++ b/docs/user-guide/forecasts-and-sensors.md
@@ -286,7 +286,7 @@ HAEO automatically detects and parses these forecast formats:
 | [AEMO NEM](https://www.home-assistant.io/integrations/aemo/)                       | `aemo`                      | Wholesale pricing (Australia)   | 30-minute intervals |
 | [EMHASS](https://github.com/davidusb-geern/emhass)                                 | `emhass`                    | Energy management forecasts     | Variable intervals  |
 | HAEO                                                                               | `haeo`                      | Chain HAEO outputs as inputs    | Variable intervals  |
-| [Nordpool](https://github.com/custom-components/nordpool)                          | `nordpool`                  | Electricity pricing (Europe)    | Hourly intervals    |
+| [Nordpool](https://github.com/custom-components/nordpool)                          | `nordpool`                  | Electricity pricing (Europe)    | Variable intervals  |
 | [HAFO](https://hafo.haeo.io)                                                       | `hafo`                      | Historical load forecasting     | Hourly intervals    |
 | [Solcast Solar](https://github.com/BJReplay/ha-solcast-solar)                      | `solcast_pv_forecast`       | Solar generation                | 30-minute intervals |
 | [Open-Meteo Solar Forecast](https://github.com/rany2/ha-open-meteo-solar-forecast) | `open_meteo_solar_forecast` | Solar generation                | Hourly intervals    |

--- a/docs/user-guide/forecasts-and-sensors.md
+++ b/docs/user-guide/forecasts-and-sensors.md
@@ -55,6 +55,7 @@ Custom template sensors that match these formats will also work.
 - [Amber Electric](https://www.home-assistant.io/integrations/amberelectric/) (electricity pricing)
 - [AEMO NEM](https://github.com/cabberley/HA_AemoNemData) (Australian electricity pricing)
 - [EMHASS](https://github.com/davidusb-geern/emhass) (energy management forecasts)
+- [Nordpool](https://github.com/custom-components/nordpool) (electricity pricing)
 - [Solcast Solar](https://github.com/BJReplay/ha-solcast-solar) (solar generation)
 - [Open-Meteo Solar Forecast](https://github.com/rany2/ha-open-meteo-solar-forecast) (solar generation)
 - HAEO sensors (chain HAEO outputs as inputs to other elements)
@@ -285,6 +286,7 @@ HAEO automatically detects and parses these forecast formats:
 | [AEMO NEM](https://www.home-assistant.io/integrations/aemo/)                       | `aemo`                      | Wholesale pricing (Australia)   | 30-minute intervals |
 | [EMHASS](https://github.com/davidusb-geern/emhass)                                 | `emhass`                    | Energy management forecasts     | Variable intervals  |
 | HAEO                                                                               | `haeo`                      | Chain HAEO outputs as inputs    | Variable intervals  |
+| [Nordpool](https://github.com/custom-components/nordpool)                          | `nordpool`                  | Electricity pricing (Europe)    | Hourly intervals    |
 | [HAFO](https://hafo.haeo.io)                                                       | `hafo`                      | Historical load forecasting     | Hourly intervals    |
 | [Solcast Solar](https://github.com/BJReplay/ha-solcast-solar)                      | `solcast_pv_forecast`       | Solar generation                | 30-minute intervals |
 | [Open-Meteo Solar Forecast](https://github.com/rany2/ha-open-meteo-solar-forecast) | `open_meteo_solar_forecast` | Solar generation                | Hourly intervals    |

--- a/tests/scenarios/visualisation/plot.py
+++ b/tests/scenarios/visualisation/plot.py
@@ -446,12 +446,14 @@ def create_stacked_visualization(output_sensors: Mapping[str, Mapping[str, Any]]
         for label, data in sorted_data
         if any(key in data for key in STACKED_FORECAST_TYPES)
     ]
-    ax_power.legend(handles=legend_handles, loc="upper left", fontsize=9, framealpha=0.9)
+    if legend_handles:
+        ax_power.legend(handles=legend_handles, loc="upper left", fontsize=9, framealpha=0.9)
 
     ax_price.set_ylabel("Price", fontsize=11)
     ax_price.grid(alpha=0.3, linestyle=":", linewidth=0.5)
     ax_price.tick_params(axis="y", labelsize=9)
-    ax_price.legend(loc="upper left", fontsize=9, framealpha=0.9)
+    if price_series:
+        ax_price.legend(loc="upper left", fontsize=9, framealpha=0.9)
 
     fig.subplots_adjust(top=0.93, bottom=0.10, left=0.08, right=0.95, hspace=0.15)
 


### PR DESCRIPTION
## Summary

Add support for [Nordpool](https://github.com/custom-components/nordpool) HACS integration sensors that provide energy pricing data via `raw_today` and `raw_tomorrow` attributes.

Closes #346

## Problem

Nordpool sensors store time-varying price forecasts in `raw_today`/`raw_tomorrow` attributes as lists of `{start, end, value}` entries. Without a dedicated extractor, HAEO fell through to the scalar fallback, reading only the current `state` value (e.g., `0.093`) as a flat constant price across all optimization periods. This caused the optimizer to see identical prices everywhere, leading to suboptimal decisions like exporting during low-price periods.

## Solution

New Nordpool extractor that:
- **Detects** sensors with a `raw_today` attribute containing `{start, end, value}` Mapping entries
- **Extracts** time-varying price forecasts as step-function boundary points
- **Combines** `raw_today` and `raw_tomorrow` when both are available
- **Derives** currency-based units dynamically (EUR/kWh, NOK/kWh, SEK/kWh, etc.)

Also fixes a visualization issue where `legend()` calls would warn when no power or price series are plotted.

## Testing

- 3 valid test cases: hourly EUR, 15-minute intervals with tomorrow data, NOK currency
- 5 invalid test cases: missing `raw_today`, empty list, bad type, missing fields, non-numeric value
- All 109 extractor tests pass, all 212 data loader tests pass