### PR TITLE
Fix element_power_balance shadow price returning wrong duals in production networks

### DIFF
--- a/custom_components/haeo/core/model/element.py
+++ b/custom_components/haeo/core/model/element.py
@@ -364,6 +364,44 @@ class NetworkElement[OutputNameT: str](Element[OutputNameT]):
                 )
         return self._produced_by_tag
 
+    @constraint
+    def _element_power_decomposition(self) -> list[highs_linear_expression] | None:
+        """Decompose element production and consumption across connection tags.
+
+        For each tag set, creates auxiliary per-tag variables and constrains their
+        sum to equal total production/consumption. Skipped when there are no
+        connection tags (simple path handled by element_power_balance).
+        """
+        tags = self.connection_tags()
+        if not tags:
+            return None
+
+        produced = self.element_power_produced()
+        consumed = self.element_power_consumed()
+
+        outbound = set(tags) if self.outbound_tags is None else (self.outbound_tags & tags)
+        inbound = set(tags) if self.inbound_tags is None else (self.inbound_tags & tags)
+
+        constraints: list[highs_linear_expression] = []
+
+        if produced is not None:
+            if outbound:
+                produced_by_tag = self._get_produced_by_tag(outbound)
+                constraints.extend(list(reduce(operator.add, produced_by_tag.values()) == produced))
+            else:
+                # Element produces but no outbound tags available — force production to 0
+                constraints.extend(list(produced == 0))
+
+        if consumed is not None:
+            if inbound:
+                consumed_by_tag = self._get_consumed_by_tag(inbound)
+                constraints.extend(list(reduce(operator.add, consumed_by_tag.values()) == consumed))
+            else:
+                # Element consumes but no inbound tags available — force consumption to 0
+                constraints.extend(list(consumed == 0))
+
+        return constraints if constraints else None
+
     @constraint(output=True, unit="$/kW")
     def element_power_balance(self) -> list[highs_linear_expression] | None:
         """Per-tag power balance: for each tag, connection + produced - consumed == 0.
@@ -395,29 +433,16 @@ class NetworkElement[OutputNameT: str](Element[OutputNameT]):
         outbound = set(tags) if self.outbound_tags is None else (self.outbound_tags & tags)
         inbound = set(tags) if self.inbound_tags is None else (self.inbound_tags & tags)
 
+        # Access decomposition variables (created lazily; also created by _element_power_decomposition)
+        produced_by_tag: dict[int, HighspyArray] = (
+            self._get_produced_by_tag(outbound) if produced is not None and outbound else {}
+        )
+        consumed_by_tag: dict[int, HighspyArray] = (
+            self._get_consumed_by_tag(inbound) if consumed is not None and inbound else {}
+        )
+
+        # Per-tag power balance only (decomposition constraints are in _element_power_decomposition)
         constraints: list[highs_linear_expression] = []
-
-        # Decompose production across outbound tags
-        produced_by_tag: dict[int, HighspyArray] = {}
-        if produced is not None:
-            if outbound:
-                produced_by_tag = self._get_produced_by_tag(outbound)
-                constraints.extend(list(reduce(operator.add, produced_by_tag.values()) == produced))
-            else:
-                # Element produces but no outbound tags available — force production to 0
-                constraints.extend(list(produced == 0))
-
-        # Decompose consumption across inbound tags
-        consumed_by_tag: dict[int, HighspyArray] = {}
-        if consumed is not None:
-            if inbound:
-                consumed_by_tag = self._get_consumed_by_tag(inbound)
-                constraints.extend(list(reduce(operator.add, consumed_by_tag.values()) == consumed))
-            else:
-                # Element consumes but no inbound tags available — force consumption to 0
-                constraints.extend(list(consumed == 0))
-
-        # Per-tag power balance
         for tag in sorted(tags):
             tag_prod = produced_by_tag.get(tag, 0)
             tag_cons = consumed_by_tag.get(tag, 0)

--- a/custom_components/haeo/core/model/tests/test_element.py
+++ b/custom_components/haeo/core/model/tests/test_element.py
@@ -11,6 +11,7 @@ import numpy as np
 import pytest
 
 from custom_components.haeo.core.model.element import ELEMENT_POWER_BALANCE, Element, NetworkElement
+from custom_components.haeo.core.model.elements.battery import Battery
 from custom_components.haeo.core.model.elements.connection import Connection
 from custom_components.haeo.core.model.elements.node import Node
 
@@ -383,3 +384,45 @@ def test_blocked_tag_skips_connection_without_tag(solver: Highs) -> None:
     tag2_in = conn1.power_into_target_for_tag(2)
     solver.minimize(-tag2_in[0])
     assert solver.val(tag2_in[0]) == pytest.approx(0.0, abs=0.01)
+
+
+# ---------------------------------------------------------------------------
+# Shadow price output has exactly n_periods values when connections are registered
+# ---------------------------------------------------------------------------
+
+
+def test_element_power_balance_shadow_price_has_n_periods_values(solver: Highs) -> None:
+    """element_power_balance output must have exactly n_periods shadow-price values.
+
+    When connections are registered (tags={0} by default), the tagged code path
+    runs. For a Battery (both production and consumption), the decomposition
+    constraints are separated into _element_power_decomposition. The
+    element_power_balance output must therefore contain exactly n_periods duals,
+    not 3*n_periods.
+    """
+    n = 2
+    periods = np.array([1.0] * n)
+    battery = Battery(
+        name="bat",
+        periods=periods,
+        solver=solver,
+        capacity=np.array([10.0] * (n + 1)),
+        initial_charge=5.0,
+    )
+
+    conn = _make_mock_connection(solver, n, {0}, "c")
+    battery.register_connection(conn, "source")
+
+    battery.constraints()
+
+    # Fix discharge (tag-0 outflow from battery) so the LP has a unique optimum
+    solver.addConstrs(-conn.power_into_source_for_tag(0) == np.array([2.0, 1.0]))
+
+    solver.run()
+
+    outputs = battery.outputs()
+    balance_output = outputs[ELEMENT_POWER_BALANCE]
+    assert len(balance_output.values) == n, (
+        f"Expected {n} shadow-price values but got {len(balance_output.values)}. "
+        "The tagged path is returning decomposition duals mixed with balance duals."
+    )


### PR DESCRIPTION
## Summary

- In production networks every `Connection` defaults to `tags={0}`, which triggers the tagged code path in `element_power_balance`. For a `Battery` (both produced and consumed), this previously returned a flat list of 3n constraints: n production decomposition + n consumption decomposition + n per-tag balance. `ReactiveConstraint.get_output()` extracted duals from all 3n, so `values[0]` was a production-decomposition dual, not the power balance dual — every `element_power_balance` shadow-price sensor reported the wrong value.
- Splits the tagged path into `_element_power_decomposition` (new, no output — decomposition constraints only) and a trimmed `element_power_balance` (output=True — per-tag balance constraints only), so shadow prices always have exactly n_periods values corresponding to the balance duals.
- Adds `test_element_power_balance_shadow_price_has_n_periods_values` which registers a real mock connection (making `connection_tags()` return `{0}`), solves, and asserts the output length is exactly n_periods — a test that would have caught this before the fix.

## Test plan

- [ ] All existing model + adapter tests pass (`uv run pytest custom_components/haeo/core/model/ custom_components/haeo/core/adapters/`)
- [ ] New test `test_element_power_balance_shadow_price_has_n_periods_values` passes
- [ ] Verify scenario tests still pass locally (`uv run pytest -m scenario`)

Made with [Cursor](https://cursor.com)