### PR TITLE
Fix participant name resolution after config entry deserialisation

### DIFF
--- a/custom_components/haeo/flows/element_flow.py
+++ b/custom_components/haeo/flows/element_flow.py
@@ -190,7 +190,7 @@ class ElementFlowMixin:
             element_type_raw = subentry.data.get(CONF_ELEMENT_TYPE)
             try:
                 element_type = ElementType(element_type_raw)
-            except (ValueError, KeyError):
+            except (TypeError, ValueError):
                 continue
 
             connectivity = ELEMENT_TYPES[element_type].connectivity

--- a/custom_components/haeo/flows/element_flow.py
+++ b/custom_components/haeo/flows/element_flow.py
@@ -187,8 +187,10 @@ class ElementFlowMixin:
             if subentry.subentry_id == current_id:
                 continue
 
-            element_type = subentry.data.get(CONF_ELEMENT_TYPE)
-            if not isinstance(element_type, ElementType):
+            element_type_raw = subentry.data.get(CONF_ELEMENT_TYPE)
+            try:
+                element_type = ElementType(element_type_raw)
+            except (ValueError, KeyError):
                 continue
 
             connectivity = ELEMENT_TYPES[element_type].connectivity

--- a/custom_components/haeo/flows/elements/tests/test_participant_deserialization.py
+++ b/custom_components/haeo/flows/elements/tests/test_participant_deserialization.py
@@ -1,0 +1,60 @@
+"""Test that participant name resolution works after config entry deserialization.
+
+After HA restart, subentry data values are deserialized as plain strings,
+not as enum instances. The participant name resolution must handle both.
+"""
+
+from types import MappingProxyType
+from typing import Any
+
+import pytest
+from homeassistant.config_entries import ConfigSubentry
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.haeo.core.const import CONF_ELEMENT_TYPE
+from custom_components.haeo.core.schema.elements import ElementType
+from custom_components.haeo.flows.conftest import create_flow
+
+
+@pytest.fixture
+def hub_entry(hass: HomeAssistant) -> MockConfigEntry:
+    """Create a hub config entry."""
+    entry = MockConfigEntry(
+        domain="haeo",
+        title="Test Hub",
+        data={"integration_type": "hub", "common": {"name": "Test", "horizon_preset": "2_days"}},
+    )
+    entry.add_to_hass(hass)
+    return entry
+
+
+def _add_subentry(hass: HomeAssistant, hub_entry: MockConfigEntry, *, element_type: Any, title: str) -> None:
+    """Add a subentry with the given element_type value."""
+    subentry = ConfigSubentry(
+        data=MappingProxyType({CONF_ELEMENT_TYPE: element_type, "name": title}),
+        subentry_type=str(element_type),
+        title=title,
+        unique_id=None,
+    )
+    hass.config_entries.async_add_subentry(hub_entry, subentry)
+
+
+async def test_participant_names_with_enum_element_type(hass: HomeAssistant, hub_entry: MockConfigEntry) -> None:
+    """Participant names resolve when element_type is an ElementType enum instance."""
+    _add_subentry(hass, hub_entry, element_type=ElementType.NODE, title="Switchboard")
+    _add_subentry(hass, hub_entry, element_type=ElementType.INVERTER, title="Inverter")
+
+    flow = create_flow(hass, hub_entry, ElementType.INVERTER)
+    participants = flow._get_participant_names()
+    assert "Switchboard" in participants
+
+
+async def test_participant_names_with_string_element_type(hass: HomeAssistant, hub_entry: MockConfigEntry) -> None:
+    """Participant names resolve when element_type is a plain string after deserialization."""
+    _add_subentry(hass, hub_entry, element_type="node", title="Switchboard")
+    _add_subentry(hass, hub_entry, element_type="inverter", title="Inverter")
+
+    flow = create_flow(hass, hub_entry, ElementType.INVERTER)
+    participants = flow._get_participant_names()
+    assert "Switchboard" in participants

--- a/custom_components/haeo/flows/elements/tests/test_participant_deserialization.py
+++ b/custom_components/haeo/flows/elements/tests/test_participant_deserialization.py
@@ -7,12 +7,12 @@ not as enum instances. The participant name resolution must handle both.
 from types import MappingProxyType
 from typing import Any
 
-import pytest
 from homeassistant.config_entries import ConfigSubentry
 from homeassistant.core import HomeAssistant
+import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.haeo.core.const import CONF_ELEMENT_TYPE
+from custom_components.haeo.core.const import CONF_ELEMENT_TYPE, CONF_NAME
 from custom_components.haeo.core.schema.elements import ElementType
 from custom_components.haeo.flows.conftest import create_flow
 
@@ -32,7 +32,7 @@ def hub_entry(hass: HomeAssistant) -> MockConfigEntry:
 def _add_subentry(hass: HomeAssistant, hub_entry: MockConfigEntry, *, element_type: Any, title: str) -> None:
     """Add a subentry with the given element_type value."""
     subentry = ConfigSubentry(
-        data=MappingProxyType({CONF_ELEMENT_TYPE: element_type, "name": title}),
+        data=MappingProxyType({CONF_ELEMENT_TYPE: element_type, CONF_NAME: title}),
         subentry_type=str(element_type),
         title=title,
         unique_id=None,


### PR DESCRIPTION
After HA restart, subentry data values are deserialized as plain strings (e.g. 'grid') rather than ElementType enum instances (ElementType.GRID). The isinstance(element_type, ElementType) check in _get_participant_names returned False for deserialized strings, causing empty participant lists in all element connection selectors.

Fix: use ElementType(value) to convert from either string or enum, with a try/except for invalid values.

Added red/green regression test with both enum and string element types.