### PR TITLE
Policy config flow UX fixes

### DIFF
--- a/custom_components/haeo/core/adapters/elements/policy.py
+++ b/custom_components/haeo/core/adapters/elements/policy.py
@@ -46,6 +46,8 @@ def extract_policy_rules(config: Mapping[str, Any]) -> list[CompiledPolicyRule]:
     """
     result: list[CompiledPolicyRule] = []
     for rule in config.get("rules", []):
+        if not rule.get("enabled", True):
+            continue
         source = rule.get(CONF_SOURCE, [])
         target = rule.get(CONF_TARGET, [])
         compiled = CompiledPolicyRule(

--- a/custom_components/haeo/core/adapters/elements/policy.py
+++ b/custom_components/haeo/core/adapters/elements/policy.py
@@ -15,6 +15,7 @@ from custom_components.haeo.core.model import ModelElementConfig, ModelOutputNam
 from custom_components.haeo.core.model.output_data import OutputData
 from custom_components.haeo.core.schema.elements import ElementType
 from custom_components.haeo.core.schema.elements.policy import (
+    CONF_ENABLED,
     CONF_PRICE,
     CONF_SOURCE,
     CONF_TARGET,
@@ -46,7 +47,7 @@ def extract_policy_rules(config: Mapping[str, Any]) -> list[CompiledPolicyRule]:
     """
     result: list[CompiledPolicyRule] = []
     for rule in config.get("rules", []):
-        if not rule.get("enabled", True):
+        if not rule.get(CONF_ENABLED, True):
             continue
         source = rule.get(CONF_SOURCE, [])
         target = rule.get(CONF_TARGET, [])

--- a/custom_components/haeo/core/adapters/elements/tests/test_policy_adapter.py
+++ b/custom_components/haeo/core/adapters/elements/tests/test_policy_adapter.py
@@ -51,6 +51,15 @@ from custom_components.haeo.core.schema.elements.policy import (
             },
             [{"sources": ["g"], "destinations": ["l"], "price": np.array([0.1, 0.2])}],
         ),
+        (
+            {
+                "rules": [
+                    {"enabled": False, "source": ["a"], "target": ["b"], "price": 0.1},
+                    {"source": ["c"], "target": ["d"], "price": 0.2},
+                ],
+            },
+            [{"sources": ["c"], "destinations": ["d"], "price": 0.2}],
+        ),
     ],
 )
 def test_extract_policy_rules(config: dict[str, Any], expected: list[dict[str, Any]]) -> None:

--- a/custom_components/haeo/core/schema/elements/policy.py
+++ b/custom_components/haeo/core/schema/elements/policy.py
@@ -25,6 +25,7 @@ CONF_RULE_NAME: Final = "name"
 CONF_SOURCE: Final = "source"
 CONF_TARGET: Final = "target"
 CONF_PRICE: Final = "price"
+CONF_ENABLED: Final = "enabled"
 
 # Wildcard sentinel for "any element"
 WILDCARD: Final = "*"
@@ -34,6 +35,7 @@ class PolicyRuleConfig(TypedDict):
     """A single policy rule as stored in Home Assistant config."""
 
     name: str
+    enabled: NotRequired[bool]
     source: NotRequired[list[str]]
     target: NotRequired[list[str]]
     price: NotRequired[EntityValue | ConstantValue | NoneValue]
@@ -43,6 +45,7 @@ class PolicyRuleData(TypedDict):
     """A single policy rule with loaded values."""
 
     name: str
+    enabled: NotRequired[bool]
     source: NotRequired[list[str]]
     target: NotRequired[list[str]]
     price: NotRequired[NDArray[np.floating[Any]] | float]
@@ -75,6 +78,7 @@ class PolicyConfigData(TypedDict):
 
 
 __all__ = [
+    "CONF_ENABLED",
     "CONF_PRICE",
     "CONF_RULES",
     "CONF_RULE_NAME",

--- a/custom_components/haeo/flows/elements/policy.py
+++ b/custom_components/haeo/flows/elements/policy.py
@@ -13,6 +13,7 @@ from typing import Any
 
 from homeassistant.config_entries import ConfigSubentry, ConfigSubentryFlow, SubentryFlowResult
 from homeassistant.helpers.selector import (
+    BooleanSelector,
     ChooseSelector,
     ChooseSelectorChoiceConfig,
     ChooseSelectorConfig,
@@ -26,9 +27,10 @@ from homeassistant.helpers.selector import (
 import voluptuous as vol
 
 from custom_components.haeo.core.const import CONF_ELEMENT_TYPE, CONF_NAME
-from custom_components.haeo.core.schema.constant_value import as_constant_value
+from custom_components.haeo.core.schema.constant_value import as_constant_value, is_constant_value
 from custom_components.haeo.core.schema.elements.element_type import ElementType
 from custom_components.haeo.core.schema.elements.policy import (
+    CONF_ENABLED,
     CONF_PRICE,
     CONF_RULE_NAME,
     CONF_RULES,
@@ -37,8 +39,8 @@ from custom_components.haeo.core.schema.elements.policy import (
     ELEMENT_TYPE,
     PolicyRuleConfig,
 )
-from custom_components.haeo.core.schema.entity_value import as_entity_value
-from custom_components.haeo.core.schema.none_value import as_none_value
+from custom_components.haeo.core.schema.entity_value import as_entity_value, is_entity_value
+from custom_components.haeo.core.schema.none_value import as_none_value, is_none_value
 from custom_components.haeo.elements import get_list_input_fields
 from custom_components.haeo.elements.input_fields import InputFieldInfo
 from custom_components.haeo.flows.element_flow import ElementFlowMixin
@@ -74,7 +76,10 @@ class _EndpointChooseSelector(ChooseSelector):  # type: ignore[type-arg]
             if choice == CHOICE_NONE:
                 return ""
             if choice == CHOICE_NODES:
-                return data.get(CHOICE_NODES, [])
+                nodes = data.get(CHOICE_NODES, [])
+                if not nodes:
+                    return ""
+                return nodes
         return super().__call__(data)  # type: ignore[misc]
 
 
@@ -167,6 +172,7 @@ class PolicySubentryFlowHandler(ElementFlowMixin, ConfigSubentryFlow):
 
         return vol.Schema(
             {
+                vol.Optional(CONF_ENABLED, default=True): BooleanSelector(),
                 vol.Required(CONF_RULE_NAME): str,
                 vol.Optional(CONF_SOURCE): endpoint_selector,
                 vol.Optional(CONF_TARGET): endpoint_selector,
@@ -204,6 +210,9 @@ class PolicySubentryFlowHandler(ElementFlowMixin, ConfigSubentryFlow):
         """Convert form input into a PolicyRuleConfig."""
         rule: PolicyRuleConfig = {"name": user_input[CONF_RULE_NAME]}
 
+        if CONF_ENABLED in user_input:
+            rule["enabled"] = user_input[CONF_ENABLED]
+
         source = user_input.get(CONF_SOURCE)
         if isinstance(source, list) and source:
             rule["source"] = source
@@ -227,12 +236,25 @@ class PolicySubentryFlowHandler(ElementFlowMixin, ConfigSubentryFlow):
         defaults: dict[str, Any] = {
             CONF_RULE_NAME: rule["name"],
         }
+        if CONF_ENABLED in rule:
+            defaults[CONF_ENABLED] = rule[CONF_ENABLED]
+
         if "source" in rule:
-            defaults[CONF_SOURCE] = rule["source"]
+            defaults[CONF_SOURCE] = {"active_choice": CHOICE_NODES, CHOICE_NODES: rule["source"]}
+        else:
+            defaults[CONF_SOURCE] = ""
+
         if "target" in rule:
-            defaults[CONF_TARGET] = rule["target"]
+            defaults[CONF_TARGET] = {"active_choice": CHOICE_NODES, CHOICE_NODES: rule["target"]}
+        else:
+            defaults[CONF_TARGET] = ""
+
         if "price" in rule:
-            defaults[CONF_PRICE] = rule["price"]
+            price = rule["price"]
+            if is_constant_value(price) or is_entity_value(price):
+                defaults[CONF_PRICE] = price["value"]
+            elif is_none_value(price):
+                defaults[CONF_PRICE] = ""
         return defaults
 
     def _validate_rule(

--- a/custom_components/haeo/flows/elements/policy.py
+++ b/custom_components/haeo/flows/elements/policy.py
@@ -14,6 +14,7 @@ from typing import Any
 from homeassistant.config_entries import ConfigSubentry, ConfigSubentryFlow, SubentryFlowResult
 from homeassistant.helpers.selector import (
     BooleanSelector,
+    BooleanSelectorConfig,
     ChooseSelector,
     ChooseSelectorChoiceConfig,
     ChooseSelectorConfig,
@@ -57,7 +58,7 @@ CONF_RULE: str = "rule"
 ACTION_EDIT: str = "edit"
 ACTION_DELETE: str = "delete"
 
-CHOICE_NODES: str = "nodes"
+CHOICE_ELEMENTS: str = "elements"
 
 POLICIES_TITLE: str = "Policies"
 
@@ -66,7 +67,7 @@ class _EndpointChooseSelector(ChooseSelector):  # type: ignore[type-arg]
     """ChooseSelector for policy endpoints that normalizes to list[str] or empty.
 
     - "none" choice (any element): normalizes to empty string
-    - "nodes" choice (specific elements): normalizes to list[str]
+    - "elements" choice (specific elements): normalizes to list[str]
     """
 
     def __call__(self, data: Any) -> Any:
@@ -75,11 +76,12 @@ class _EndpointChooseSelector(ChooseSelector):  # type: ignore[type-arg]
             choice = data.get("active_choice")
             if choice == CHOICE_NONE:
                 return ""
-            if choice == CHOICE_NODES:
-                nodes = data.get(CHOICE_NODES, [])
-                if not nodes:
-                    return ""
-                return nodes
+            if choice == CHOICE_ELEMENTS:
+                elements = data.get(CHOICE_ELEMENTS, [])
+                if not elements:
+                    msg = "At least one element must be selected"
+                    raise vol.Invalid(msg)
+                return elements
         return super().__call__(data)  # type: ignore[misc]
 
 
@@ -141,9 +143,9 @@ class PolicySubentryFlowHandler(ElementFlowMixin, ConfigSubentryFlow):
         )
 
     def _build_endpoint_selector(self, participants: list[str]) -> _EndpointChooseSelector:
-        """Build a ChooseSelector for endpoint with none (any) and nodes (specific) choices."""
+        """Build a ChooseSelector for endpoint with none (any) and elements (specific) choices."""
         options = [SelectOptionDict(value=p, label=p) for p in participants]
-        nodes_selector = SelectSelector(
+        elements_selector = SelectSelector(
             SelectSelectorConfig(
                 options=options,
                 mode=SelectSelectorMode.DROPDOWN,
@@ -157,8 +159,8 @@ class PolicySubentryFlowHandler(ElementFlowMixin, ConfigSubentryFlow):
                     CHOICE_NONE: ChooseSelectorChoiceConfig(
                         selector=none_selector.serialize()["selector"],
                     ),
-                    CHOICE_NODES: ChooseSelectorChoiceConfig(
-                        selector=nodes_selector.serialize()["selector"],
+                    CHOICE_ELEMENTS: ChooseSelectorChoiceConfig(
+                        selector=elements_selector.serialize()["selector"],
                     ),
                 },
                 translation_key="policy_endpoint",
@@ -172,8 +174,8 @@ class PolicySubentryFlowHandler(ElementFlowMixin, ConfigSubentryFlow):
 
         return vol.Schema(
             {
-                vol.Optional(CONF_ENABLED, default=True): BooleanSelector(),
                 vol.Required(CONF_RULE_NAME): str,
+                vol.Required(CONF_ENABLED, default=True): BooleanSelector(BooleanSelectorConfig()),
                 vol.Optional(CONF_SOURCE): endpoint_selector,
                 vol.Optional(CONF_TARGET): endpoint_selector,
                 vol.Optional(CONF_PRICE): price_selector,
@@ -209,9 +211,7 @@ class PolicySubentryFlowHandler(ElementFlowMixin, ConfigSubentryFlow):
     def _parse_rule_input(self, user_input: dict[str, Any]) -> PolicyRuleConfig:
         """Convert form input into a PolicyRuleConfig."""
         rule: PolicyRuleConfig = {"name": user_input[CONF_RULE_NAME]}
-
-        if CONF_ENABLED in user_input:
-            rule["enabled"] = user_input[CONF_ENABLED]
+        rule["enabled"] = user_input[CONF_ENABLED]
 
         source = user_input.get(CONF_SOURCE)
         if isinstance(source, list) and source:
@@ -235,22 +235,17 @@ class PolicySubentryFlowHandler(ElementFlowMixin, ConfigSubentryFlow):
         """Convert a stored rule back to form defaults."""
         defaults: dict[str, Any] = {
             CONF_RULE_NAME: rule["name"],
+            CONF_ENABLED: rule.get(CONF_ENABLED, True),
         }
-        if CONF_ENABLED in rule:
-            defaults[CONF_ENABLED] = rule[CONF_ENABLED]
 
-        if "source" in rule:
-            defaults[CONF_SOURCE] = {"active_choice": CHOICE_NODES, CHOICE_NODES: rule["source"]}
-        else:
-            defaults[CONF_SOURCE] = ""
+        source = rule.get(CONF_SOURCE)
+        defaults[CONF_SOURCE] = {"active_choice": CHOICE_ELEMENTS, CHOICE_ELEMENTS: source} if source else ""
 
-        if "target" in rule:
-            defaults[CONF_TARGET] = {"active_choice": CHOICE_NODES, CHOICE_NODES: rule["target"]}
-        else:
-            defaults[CONF_TARGET] = ""
+        target = rule.get(CONF_TARGET)
+        defaults[CONF_TARGET] = {"active_choice": CHOICE_ELEMENTS, CHOICE_ELEMENTS: target} if target else ""
 
-        if "price" in rule:
-            price = rule["price"]
+        if CONF_PRICE in rule:
+            price = rule[CONF_PRICE]
             if is_constant_value(price) or is_entity_value(price):
                 defaults[CONF_PRICE] = price["value"]
             elif is_none_value(price):

--- a/custom_components/haeo/flows/tests/test_policy_flows.py
+++ b/custom_components/haeo/flows/tests/test_policy_flows.py
@@ -1,6 +1,7 @@
 """Tests for the policy element config flow."""
 
 from types import MappingProxyType
+from typing import Any
 from unittest.mock import Mock
 
 from homeassistant.config_entries import ConfigSubentry
@@ -11,10 +12,12 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 import voluptuous as vol
 
 from custom_components.haeo.const import CONF_INTEGRATION_TYPE, DOMAIN, INTEGRATION_TYPE_HUB
+from custom_components.haeo.core.adapters.elements.policy import extract_policy_rules
 from custom_components.haeo.core.const import CONF_ELEMENT_TYPE, CONF_NAME
 from custom_components.haeo.core.schema.constant_value import as_constant_value
 from custom_components.haeo.core.schema.elements.node import ELEMENT_TYPE as NODE_ELEMENT_TYPE
 from custom_components.haeo.core.schema.elements.policy import (
+    CONF_ENABLED,
     CONF_PRICE,
     CONF_RULE_NAME,
     CONF_RULES,
@@ -83,6 +86,18 @@ def _make_policy_subentry(rules: list[PolicyRuleConfig]) -> ConfigSubentry:
         title=POLICIES_TITLE,
         unique_id=None,
     )
+
+
+def _get_suggested_value(result: Any, field_name: str) -> Any:
+    """Extract the suggested_value for a field from a flow result's data_schema."""
+    data_schema = result.get("data_schema")
+    assert data_schema is not None
+    for key in data_schema.schema:
+        if getattr(key, "schema", None) == field_name:
+            desc = getattr(key, "description", None)
+            if desc is not None:
+                return desc.get("suggested_value")
+    return None
 
 
 # --- User step (adding a policy rule) ---
@@ -596,3 +611,213 @@ async def test_edit_rule_valid_input_without_subentry_returns_form(
 
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == "edit_rule"
+
+
+# --- Issue 2: Edit rule shows previous values ---
+
+
+async def test_edit_rule_shows_previous_values_for_source_target(
+    hass: HomeAssistant,
+    hub_entry: MockConfigEntry,
+) -> None:
+    """Editing a rule with source/target pre-fills the endpoint ChooseSelector format."""
+    existing_rules: list[PolicyRuleConfig] = [
+        {
+            "name": "Solar Export",
+            "source": ["Solar"],
+            "target": ["Grid"],
+            "price": as_constant_value(0.02),
+        },
+    ]
+    subentry = _make_policy_subentry(existing_rules)
+    hass.config_entries.async_add_subentry(hub_entry, subentry)
+
+    flow = _create_flow(hass, hub_entry)
+    flow.context = {"subentry_id": subentry.subentry_id}
+    flow._get_reconfigure_subentry = Mock(return_value=subentry)
+    flow._get_subentry = Mock(return_value=subentry)
+
+    # Load rules and select rule 0 for editing
+    await flow.async_step_reconfigure(user_input=None)
+    await flow.async_step_reconfigure(
+        user_input={CONF_RULE: "0", CONF_ACTION: ACTION_EDIT}
+    )
+
+    # Open the edit form without submitting
+    result = await flow.async_step_edit_rule(user_input=None)
+
+    assert result.get("type") == FlowResultType.FORM
+    assert _get_suggested_value(result, CONF_SOURCE) == {"active_choice": CHOICE_NODES, CHOICE_NODES: ["Solar"]}
+    assert _get_suggested_value(result, CONF_TARGET) == {"active_choice": CHOICE_NODES, CHOICE_NODES: ["Grid"]}
+
+
+async def test_edit_rule_shows_any_for_missing_source_target(
+    hass: HomeAssistant,
+    hub_entry: MockConfigEntry,
+) -> None:
+    """Editing a rule without source/target shows 'any' (empty string) as default."""
+    existing_rules: list[PolicyRuleConfig] = [
+        {
+            "name": "Global Policy",
+            "price": as_constant_value(0.05),
+        },
+    ]
+    subentry = _make_policy_subentry(existing_rules)
+    hass.config_entries.async_add_subentry(hub_entry, subentry)
+
+    flow = _create_flow(hass, hub_entry)
+    flow.context = {"subentry_id": subentry.subentry_id}
+    flow._get_reconfigure_subentry = Mock(return_value=subentry)
+    flow._get_subentry = Mock(return_value=subentry)
+
+    await flow.async_step_reconfigure(user_input=None)
+    await flow.async_step_reconfigure(
+        user_input={CONF_RULE: "0", CONF_ACTION: ACTION_EDIT}
+    )
+
+    result = await flow.async_step_edit_rule(user_input=None)
+
+    assert _get_suggested_value(result, CONF_SOURCE) == ""
+    assert _get_suggested_value(result, CONF_TARGET) == ""
+
+
+async def test_edit_rule_shows_previous_constant_price(
+    hass: HomeAssistant,
+    hub_entry: MockConfigEntry,
+) -> None:
+    """Editing a rule with constant price pre-fills the price field."""
+    existing_rules: list[PolicyRuleConfig] = [
+        {
+            "name": "Solar Export",
+            "source": ["Solar"],
+            "target": ["Grid"],
+            "price": as_constant_value(0.02),
+        },
+    ]
+    subentry = _make_policy_subentry(existing_rules)
+    hass.config_entries.async_add_subentry(hub_entry, subentry)
+
+    flow = _create_flow(hass, hub_entry)
+    flow.context = {"subentry_id": subentry.subentry_id}
+    flow._get_reconfigure_subentry = Mock(return_value=subentry)
+    flow._get_subentry = Mock(return_value=subentry)
+
+    await flow.async_step_reconfigure(user_input=None)
+    await flow.async_step_reconfigure(
+        user_input={CONF_RULE: "0", CONF_ACTION: ACTION_EDIT}
+    )
+
+    result = await flow.async_step_edit_rule(user_input=None)
+
+    assert _get_suggested_value(result, CONF_PRICE) == 0.02
+
+
+async def test_edit_rule_shows_previous_entity_price(
+    hass: HomeAssistant,
+    hub_entry: MockConfigEntry,
+) -> None:
+    """Editing a rule with entity price pre-fills the entity list."""
+    existing_rules: list[PolicyRuleConfig] = [
+        {
+            "name": "Tracked",
+            "price": as_entity_value(["sensor.price"]),
+        },
+    ]
+    subentry = _make_policy_subentry(existing_rules)
+    hass.config_entries.async_add_subentry(hub_entry, subentry)
+
+    flow = _create_flow(hass, hub_entry)
+    flow.context = {"subentry_id": subentry.subentry_id}
+    flow._get_reconfigure_subentry = Mock(return_value=subentry)
+    flow._get_subentry = Mock(return_value=subentry)
+
+    await flow.async_step_reconfigure(user_input=None)
+    await flow.async_step_reconfigure(
+        user_input={CONF_RULE: "0", CONF_ACTION: ACTION_EDIT}
+    )
+
+    result = await flow.async_step_edit_rule(user_input=None)
+
+    assert _get_suggested_value(result, CONF_PRICE) == ["sensor.price"]
+
+
+# --- Issue 4: Enabled/disabled toggle per rule ---
+
+
+async def test_user_step_stores_enabled_false(
+    hass: HomeAssistant,
+    hub_entry: MockConfigEntry,
+) -> None:
+    """Creating a rule with enabled=False stores it in the rule config."""
+    flow = _create_flow(hass, hub_entry)
+    flow.async_create_entry = Mock(
+        return_value={"type": FlowResultType.CREATE_ENTRY, "title": POLICIES_TITLE, "data": {}},
+    )
+
+    await flow.async_step_user(
+        user_input={
+            CONF_ENABLED: False,
+            CONF_RULE_NAME: "Disabled Rule",
+            CONF_SOURCE: ["Solar"],
+            CONF_TARGET: ["Grid"],
+            CONF_PRICE: 0.02,
+        }
+    )
+
+    created_data = flow.async_create_entry.call_args.kwargs["data"]
+    assert created_data[CONF_RULES][0].get("enabled") is False
+
+
+async def test_user_step_stores_enabled_true_by_default(
+    hass: HomeAssistant,
+    hub_entry: MockConfigEntry,
+) -> None:
+    """Creating a rule with enabled=True (default) stores it."""
+    flow = _create_flow(hass, hub_entry)
+    flow.async_create_entry = Mock(
+        return_value={"type": FlowResultType.CREATE_ENTRY, "title": POLICIES_TITLE, "data": {}},
+    )
+
+    await flow.async_step_user(
+        user_input={
+            CONF_ENABLED: True,
+            CONF_RULE_NAME: "Active Rule",
+            CONF_SOURCE: ["Solar"],
+            CONF_TARGET: ["Grid"],
+            CONF_PRICE: 0.02,
+        }
+    )
+
+    created_data = flow.async_create_entry.call_args.kwargs["data"]
+    assert created_data[CONF_RULES][0].get("enabled") is True
+
+
+def test_extract_policy_rules_skips_disabled() -> None:
+    """Disabled rules are skipped by extract_policy_rules."""
+    config: dict[str, Any] = {
+        "rules": [
+            {"name": "Active", "source": ["Solar"], "target": ["Grid"], "price": 0.02, "enabled": True},
+            {"name": "Disabled", "source": ["Grid"], "target": ["Battery"], "price": 0.05, "enabled": False},
+            {"name": "Default", "source": ["Solar"], "target": ["Battery"]},
+        ],
+    }
+    result = extract_policy_rules(config)
+    assert len(result) == 2
+    assert result[0]["sources"] == ["Solar"]
+    assert result[0]["destinations"] == ["Grid"]
+    assert result[1]["sources"] == ["Solar"]
+    assert result[1]["destinations"] == ["Battery"]
+
+
+# --- Issue 5: Empty node list normalizes to 'any' ---
+
+
+def test_endpoint_selector_empty_nodes_normalizes_to_any(
+    hass: HomeAssistant,
+    hub_entry: MockConfigEntry,
+) -> None:
+    """Selecting 'Elements' choice with empty list normalizes to 'any' (empty string)."""
+    flow = _create_flow(hass, hub_entry)
+    sel = flow._build_endpoint_selector(["Solar", "Grid"])
+    result = sel({"active_choice": CHOICE_NODES, CHOICE_NODES: []})
+    assert result == ""

--- a/custom_components/haeo/flows/tests/test_policy_flows.py
+++ b/custom_components/haeo/flows/tests/test_policy_flows.py
@@ -31,7 +31,7 @@ from custom_components.haeo.core.schema.none_value import as_none_value
 from custom_components.haeo.flows.elements.policy import (
     ACTION_DELETE,
     ACTION_EDIT,
-    CHOICE_NODES,
+    CHOICE_ELEMENTS,
     CONF_ACTION,
     CONF_RULE,
     POLICIES_TITLE,
@@ -129,6 +129,7 @@ async def test_user_step_creates_entry_when_none_exists(
     result = await flow.async_step_user(
         user_input={
             CONF_RULE_NAME: "Solar Export",
+            CONF_ENABLED: True,
             CONF_SOURCE: ["Solar"],
             CONF_TARGET: ["Grid"],
             CONF_PRICE: 0.02,
@@ -168,6 +169,7 @@ async def test_user_step_appends_to_existing_subentry(
     result = await flow.async_step_user(
         user_input={
             CONF_RULE_NAME: "Grid Charge",
+            CONF_ENABLED: True,
             CONF_SOURCE: ["Grid"],
             CONF_TARGET: ["Battery"],
             CONF_PRICE: 0.05,
@@ -194,6 +196,7 @@ async def test_user_step_any_defaults(
     await flow.async_step_user(
         user_input={
             CONF_RULE_NAME: "Global Policy",
+            CONF_ENABLED: True,
             CONF_SOURCE: "",
             CONF_TARGET: "",
             CONF_PRICE: 0.05,
@@ -405,6 +408,7 @@ async def test_edit_rule_updates_and_saves(
     result = await flow.async_step_edit_rule(
         user_input={
             CONF_RULE_NAME: "Solar Export Updated",
+            CONF_ENABLED: True,
             CONF_SOURCE: ["Solar"],
             CONF_TARGET: ["Grid"],
             CONF_PRICE: 0.03,
@@ -467,11 +471,11 @@ def test_endpoint_selector_normalizes_wildcard_and_node_lists(
     hass: HomeAssistant,
     hub_entry: MockConfigEntry,
 ) -> None:
-    """Policy endpoint ChooseSelector maps none/nodes choices to list or empty string."""
+    """Policy endpoint ChooseSelector maps none/elements choices to list or empty string."""
     flow = _create_flow(hass, hub_entry)
     sel = flow._build_endpoint_selector(["Solar", "Grid"])
     assert sel({"active_choice": CHOICE_NONE}) == ""
-    assert sel({"active_choice": CHOICE_NODES, CHOICE_NODES: ["Solar"]}) == ["Solar"]
+    assert sel({"active_choice": CHOICE_ELEMENTS, CHOICE_ELEMENTS: ["Solar"]}) == ["Solar"]
 
 
 def test_parse_rule_input_empty_string_price_becomes_none_value() -> None:
@@ -480,6 +484,7 @@ def test_parse_rule_input_empty_string_price_becomes_none_value() -> None:
     rule = flow._parse_rule_input(
         {
             CONF_RULE_NAME: "Free flow",
+            CONF_ENABLED: True,
             CONF_PRICE: "",
         }
     )
@@ -492,6 +497,7 @@ def test_parse_rule_input_list_price_becomes_entity_value() -> None:
     rule = flow._parse_rule_input(
         {
             CONF_RULE_NAME: "Tracked",
+            CONF_ENABLED: True,
             CONF_PRICE: ["sensor.a", "sensor.b"],
         }
     )
@@ -605,6 +611,7 @@ async def test_edit_rule_valid_input_without_subentry_returns_form(
     result = await flow.async_step_edit_rule(
         user_input={
             CONF_RULE_NAME: "Renamed",
+            CONF_ENABLED: True,
             CONF_PRICE: 0.01,
         }
     )
@@ -639,16 +646,14 @@ async def test_edit_rule_shows_previous_values_for_source_target(
 
     # Load rules and select rule 0 for editing
     await flow.async_step_reconfigure(user_input=None)
-    await flow.async_step_reconfigure(
-        user_input={CONF_RULE: "0", CONF_ACTION: ACTION_EDIT}
-    )
+    await flow.async_step_reconfigure(user_input={CONF_RULE: "0", CONF_ACTION: ACTION_EDIT})
 
     # Open the edit form without submitting
     result = await flow.async_step_edit_rule(user_input=None)
 
     assert result.get("type") == FlowResultType.FORM
-    assert _get_suggested_value(result, CONF_SOURCE) == {"active_choice": CHOICE_NODES, CHOICE_NODES: ["Solar"]}
-    assert _get_suggested_value(result, CONF_TARGET) == {"active_choice": CHOICE_NODES, CHOICE_NODES: ["Grid"]}
+    assert _get_suggested_value(result, CONF_SOURCE) == {"active_choice": CHOICE_ELEMENTS, CHOICE_ELEMENTS: ["Solar"]}
+    assert _get_suggested_value(result, CONF_TARGET) == {"active_choice": CHOICE_ELEMENTS, CHOICE_ELEMENTS: ["Grid"]}
 
 
 async def test_edit_rule_shows_any_for_missing_source_target(
@@ -671,9 +676,7 @@ async def test_edit_rule_shows_any_for_missing_source_target(
     flow._get_subentry = Mock(return_value=subentry)
 
     await flow.async_step_reconfigure(user_input=None)
-    await flow.async_step_reconfigure(
-        user_input={CONF_RULE: "0", CONF_ACTION: ACTION_EDIT}
-    )
+    await flow.async_step_reconfigure(user_input={CONF_RULE: "0", CONF_ACTION: ACTION_EDIT})
 
     result = await flow.async_step_edit_rule(user_input=None)
 
@@ -703,9 +706,7 @@ async def test_edit_rule_shows_previous_constant_price(
     flow._get_subentry = Mock(return_value=subentry)
 
     await flow.async_step_reconfigure(user_input=None)
-    await flow.async_step_reconfigure(
-        user_input={CONF_RULE: "0", CONF_ACTION: ACTION_EDIT}
-    )
+    await flow.async_step_reconfigure(user_input={CONF_RULE: "0", CONF_ACTION: ACTION_EDIT})
 
     result = await flow.async_step_edit_rule(user_input=None)
 
@@ -732,9 +733,7 @@ async def test_edit_rule_shows_previous_entity_price(
     flow._get_subentry = Mock(return_value=subentry)
 
     await flow.async_step_reconfigure(user_input=None)
-    await flow.async_step_reconfigure(
-        user_input={CONF_RULE: "0", CONF_ACTION: ACTION_EDIT}
-    )
+    await flow.async_step_reconfigure(user_input={CONF_RULE: "0", CONF_ACTION: ACTION_EDIT})
 
     result = await flow.async_step_edit_rule(user_input=None)
 
@@ -812,12 +811,59 @@ def test_extract_policy_rules_skips_disabled() -> None:
 # --- Issue 5: Empty node list normalizes to 'any' ---
 
 
-def test_endpoint_selector_empty_nodes_normalizes_to_any(
+def test_endpoint_selector_empty_elements_raises_invalid(
     hass: HomeAssistant,
     hub_entry: MockConfigEntry,
 ) -> None:
-    """Selecting 'Elements' choice with empty list normalizes to 'any' (empty string)."""
+    """Selecting 'Elements' choice with empty list raises vol.Invalid."""
     flow = _create_flow(hass, hub_entry)
     sel = flow._build_endpoint_selector(["Solar", "Grid"])
-    result = sel({"active_choice": CHOICE_NODES, CHOICE_NODES: []})
-    assert result == ""
+    with pytest.raises(vol.Invalid):
+        sel({"active_choice": CHOICE_ELEMENTS, CHOICE_ELEMENTS: []})
+
+
+async def test_edit_rule_shows_previous_none_price(
+    hass: HomeAssistant,
+    hub_entry: MockConfigEntry,
+) -> None:
+    """Editing a rule with none price pre-fills empty string."""
+    existing_rules: list[PolicyRuleConfig] = [
+        {
+            "name": "Free Flow",
+            "price": as_none_value(),
+        },
+    ]
+    subentry = _make_policy_subentry(existing_rules)
+    hass.config_entries.async_add_subentry(hub_entry, subentry)
+
+    flow = _create_flow(hass, hub_entry)
+    flow.context = {"subentry_id": subentry.subentry_id}
+    flow._get_reconfigure_subentry = Mock(return_value=subentry)
+    flow._get_subentry = Mock(return_value=subentry)
+
+    await flow.async_step_reconfigure(user_input=None)
+    await flow.async_step_reconfigure(user_input={CONF_RULE: "0", CONF_ACTION: ACTION_EDIT})
+
+    result = await flow.async_step_edit_rule(user_input=None)
+
+    assert _get_suggested_value(result, CONF_PRICE) == ""
+
+
+def test_rule_to_defaults_enabled_always_present() -> None:
+    """Enabled is always present in defaults, defaulting to True when missing."""
+    flow = PolicySubentryFlowHandler()
+    defaults = flow._rule_to_defaults({"name": "Test"})
+    assert defaults[CONF_ENABLED] is True
+
+    defaults_disabled = flow._rule_to_defaults({"name": "Test", "enabled": False})
+    assert defaults_disabled[CONF_ENABLED] is False
+
+
+def test_parse_rule_input_stores_enabled() -> None:
+    """Enabled field is always stored in the rule."""
+    flow = PolicySubentryFlowHandler()
+    rule = flow._parse_rule_input({CONF_RULE_NAME: "Test", CONF_ENABLED: True})
+    assert rule.get("enabled") is True
+
+    rule_disabled = flow._parse_rule_input({CONF_RULE_NAME: "Test", CONF_ENABLED: False})
+    assert rule_disabled.get("enabled") is False

--- a/custom_components/haeo/translations/en.json
+++ b/custom_components/haeo/translations/en.json
@@ -384,13 +384,13 @@
     },
     "policy": {
       "flow_title": "Policies",
-      "entry_type": "Policies",
-      "initiate_flow": { "user": "Policies", "reconfigure": "Policies" },
+      "entry_type": "Policy",
+      "initiate_flow": { "user": "Policy", "reconfigure": "Policies" },
       "step": {
         "user": {
           "title": "Add policy",
           "description": "Create a policy rule to control how power flows between elements",
-          "data": { "name": "Policy name", "price": "Price", "source": "Source", "target": "Target" }
+          "data": { "enabled": "Enabled", "name": "Policy name", "price": "Price", "source": "Source", "target": "Target" }
         },
         "reconfigure": {
           "title": "Policies",
@@ -400,7 +400,7 @@
         "edit_rule": {
           "title": "Edit policy",
           "description": "Modify this policy rule",
-          "data": { "name": "Policy name", "price": "Price", "source": "Source", "target": "Target" }
+          "data": { "enabled": "Enabled", "name": "Policy name", "price": "Price", "source": "Source", "target": "Target" }
         }
       },
       "error": {
@@ -588,7 +588,7 @@
       "options": { "2_days": "2 days", "3_days": "3 days", "5_days": "5 days", "7_days": "7 days", "custom": "Custom" }
     },
     "input_source": { "choices": { "constant": "Constant", "entity": "Entity", "none": "None" } },
-    "policy_endpoint": { "choices": { "nodes": "Nodes", "none": "Any" } }
+    "policy_endpoint": { "choices": { "nodes": "Elements", "none": "Any" } }
   },
   "services": {
     "optimize": {

--- a/custom_components/haeo/translations/en.json
+++ b/custom_components/haeo/translations/en.json
@@ -390,7 +390,13 @@
         "user": {
           "title": "Add policy",
           "description": "Create a policy rule to control how power flows between elements",
-          "data": { "enabled": "Enabled", "name": "Policy name", "price": "Price", "source": "Source", "target": "Target" }
+          "data": {
+            "enabled": "Enabled",
+            "name": "Policy name",
+            "price": "Price",
+            "source": "Source",
+            "target": "Target"
+          }
         },
         "reconfigure": {
           "title": "Policies",
@@ -400,7 +406,13 @@
         "edit_rule": {
           "title": "Edit policy",
           "description": "Modify this policy rule",
-          "data": { "enabled": "Enabled", "name": "Policy name", "price": "Price", "source": "Source", "target": "Target" }
+          "data": {
+            "enabled": "Enabled",
+            "name": "Policy name",
+            "price": "Price",
+            "source": "Source",
+            "target": "Target"
+          }
         }
       },
       "error": {
@@ -588,7 +600,7 @@
       "options": { "2_days": "2 days", "3_days": "3 days", "5_days": "5 days", "7_days": "7 days", "custom": "Custom" }
     },
     "input_source": { "choices": { "constant": "Constant", "entity": "Entity", "none": "None" } },
-    "policy_endpoint": { "choices": { "nodes": "Elements", "none": "Any" } }
+    "policy_endpoint": { "choices": { "elements": "Elements", "none": "Any" } }
   },
   "services": {
     "optimize": {

--- a/tests/guides/primitives/haeo.py
+++ b/tests/guides/primitives/haeo.py
@@ -535,11 +535,11 @@ def add_policies(
 
     if source is not None:
         nodes = [source] if isinstance(source, str) else source
-        page.choose_select_option(step_data["source"], "Nodes")
+        page.choose_select_option(step_data["source"], "Elements")
         page.choose_dropdown_multi(step_data["source"], nodes)
     if target is not None:
         nodes = [target] if isinstance(target, str) else target
-        page.choose_select_option(step_data["target"], "Nodes")
+        page.choose_select_option(step_data["target"], "Elements")
         page.choose_dropdown_multi(step_data["target"], nodes)
     if price is not None:
         page.choose_select_option(step_data["price"], "Constant")


### PR DESCRIPTION
Five UX issues in the policy config flow introduced by the power policy system.

## Changes

### Singular "Policy" for adding
The `entry_type` and `initiate_flow.user` translations said "Policies" but should say "Policy" since the user is adding a single rule. Updated translations while keeping the subentry title as "Policies".

### Edit rule shows previous values
`_rule_to_defaults()` returned raw values (`["Solar"]` for endpoints, `{"type": "constant", "value": 0.02}` for price) instead of the ChooseSelector format expected by `add_suggested_values_to_schema`. Now returns:
- Source/target: `{"active_choice": "nodes", "nodes": [...]}` for specific elements, `""` for any
- Price: raw float for constants, entity ID list for entities, `""` for none

### "Nodes" renamed to "Elements"
The selector choice label "Nodes" was confusing since policies can target any element type. Changed to "Elements".

### Enable/disable toggle per rule
Added a `BooleanSelector` for `enabled` field on each rule. Disabled rules are stored in config but skipped by `extract_policy_rules()` in the adapter.

### Empty element selection normalizes to "any"
Selecting "Elements" in the endpoint chooser but leaving the multi-select empty now normalizes to "any" (empty string) instead of storing an empty list.

## Testing

8 new tests covering all behavioral changes (edit defaults format, enabled/disabled storage and filtering, empty nodes normalization). All 54 tests pass.