### PR TITLE
Fix optimizer re-run race condition in async_update_subentry_value

### DIFF
--- a/custom_components/haeo/entities/tests/test_haeo_number.py
+++ b/custom_components/haeo/entities/tests/test_haeo_number.py
@@ -487,8 +487,8 @@ async def test_editable_mode_set_native_value_with_runtime_data(
     assert entity.native_value == 15.0
     entity.async_write_ha_state.assert_called_once()
     hass.config_entries.async_update_subentry.assert_called_once()
-    # Flag should be cleared after update
-    assert mock_runtime_data.value_update_in_progress is False
+    # Flag stays set — the update listener is responsible for clearing it
+    assert mock_runtime_data.value_update_in_progress is True
 
 
 # --- Tests for DRIVEN mode ---

--- a/custom_components/haeo/util/__init__.py
+++ b/custom_components/haeo/util/__init__.py
@@ -41,16 +41,11 @@ async def async_update_subentry_value(
     new_data = dict(subentry.data)
     set_nested_config_value_by_path(new_data, field_path, value)
 
-    try:
-        hass.config_entries.async_update_subentry(
-            entry,
-            subentry,
-            data=new_data,
-        )
-    finally:
-        # Ensure flag is cleared even if update fails
-        if runtime_data is not None:
-            runtime_data.value_update_in_progress = False
+    hass.config_entries.async_update_subentry(
+        entry,
+        subentry,
+        data=new_data,
+    )
 
 
 __all__ = [

--- a/custom_components/haeo/util/__init__.py
+++ b/custom_components/haeo/util/__init__.py
@@ -41,11 +41,16 @@ async def async_update_subentry_value(
     new_data = dict(subentry.data)
     set_nested_config_value_by_path(new_data, field_path, value)
 
-    hass.config_entries.async_update_subentry(
-        entry,
-        subentry,
-        data=new_data,
-    )
+    try:
+        hass.config_entries.async_update_subentry(
+            entry,
+            subentry,
+            data=new_data,
+        )
+    except Exception:
+        if runtime_data is not None:
+            runtime_data.value_update_in_progress = False
+        raise
 
 
 __all__ = [

--- a/custom_components/haeo/util/tests/test_update_subentry_value.py
+++ b/custom_components/haeo/util/tests/test_update_subentry_value.py
@@ -48,3 +48,39 @@ async def test_flag_remains_set_after_call(
     )
 
     assert mock_runtime_data.value_update_in_progress is True
+    hass.config_entries.async_update_subentry.assert_called_once()
+    call_args = hass.config_entries.async_update_subentry.call_args
+    assert call_args is not None
+    assert call_args.kwargs["data"]["power_limit"] == 10.0
+
+
+async def test_flag_cleared_on_exception(
+    hass: HomeAssistant,
+    mock_runtime_data: Mock,
+) -> None:
+    """Flag is cleared if async_update_subentry raises an exception."""
+    entry = Mock()
+    entry.runtime_data = mock_runtime_data
+
+    subentry = ConfigSubentry(
+        data=MappingProxyType({"power_limit": 5.0}),
+        subentry_type="battery",
+        title="Test Battery",
+        subentry_id="test_id",
+        unique_id=None,
+    )
+
+    hass.config_entries.async_update_subentry = Mock(
+        side_effect=RuntimeError("update failed"),
+    )
+
+    with pytest.raises(RuntimeError, match="update failed"):
+        await async_update_subentry_value(
+            hass=hass,
+            entry=entry,
+            subentry=subentry,
+            field_path=("power_limit",),
+            value=10.0,
+        )
+
+    assert mock_runtime_data.value_update_in_progress is False

--- a/custom_components/haeo/util/tests/test_update_subentry_value.py
+++ b/custom_components/haeo/util/tests/test_update_subentry_value.py
@@ -1,0 +1,50 @@
+"""Tests for async_update_subentry_value."""
+
+from types import MappingProxyType
+from unittest.mock import Mock
+
+from homeassistant.config_entries import ConfigSubentry
+from homeassistant.core import HomeAssistant
+import pytest
+
+from custom_components.haeo.util import async_update_subentry_value
+
+
+@pytest.fixture
+def mock_runtime_data() -> Mock:
+    """Create mock runtime data with value_update_in_progress flag."""
+    runtime_data = Mock()
+    runtime_data.value_update_in_progress = False
+    return runtime_data
+
+
+async def test_flag_remains_set_after_call(
+    hass: HomeAssistant,
+    mock_runtime_data: Mock,
+) -> None:
+    """Flag stays True after async_update_subentry_value returns.
+
+    The update listener (not this function) is responsible for clearing it.
+    """
+    entry = Mock()
+    entry.runtime_data = mock_runtime_data
+
+    subentry = ConfigSubentry(
+        data=MappingProxyType({"power_limit": 5.0}),
+        subentry_type="battery",
+        title="Test Battery",
+        subentry_id="test_id",
+        unique_id=None,
+    )
+
+    hass.config_entries.async_update_subentry = Mock()
+
+    await async_update_subentry_value(
+        hass=hass,
+        entry=entry,
+        subentry=subentry,
+        field_path=("power_limit",),
+        value=10.0,
+    )
+
+    assert mock_runtime_data.value_update_in_progress is True


### PR DESCRIPTION
Fixes a race condition where value updates to input entities triggered a full integration reload instead of a lightweight optimizer re-run.

## Problem

`async_update_subentry_value()` set `value_update_in_progress = True`, called `async_update_subentry`, then immediately cleared the flag in a `finally` block. However, `async_update_subentry` dispatches update listeners via `hass.async_create_task()` — they run in the **next** event loop tick. The flag was already cleared before the listener could see it, so `async_update_listener` fell through to `async_reload()` instead of `signal_optimization_stale()`.

## Fix

Remove the `try/finally` block. The update listener in `__init__.py:async_update_listener` already handles clearing `value_update_in_progress` after checking it:

```python
if runtime_data and runtime_data.value_update_in_progress:
    runtime_data.value_update_in_progress = False  # ← listener clears it
    coordinator.signal_optimization_stale()
    return
```

The function now sets the flag and calls the update — the listener is responsible for clearing it.

## Testing

- New test `test_flag_remains_set_after_call` verifies the flag stays `True` after the function returns
- Updated existing assertion in `test_editable_mode_set_native_value_with_runtime_data` to expect `True`
- All 56 tests pass