### PR TITLE
Negate battery charge incentive price in v1.4 migration

### DIFF
--- a/custom_components/haeo/migrations/tests/test_v1_4.py
+++ b/custom_components/haeo/migrations/tests/test_v1_4.py
@@ -237,6 +237,61 @@ async def test_v1_4_appends_migrated_rules_to_existing_policy_subentry(hass: Hom
     assert rules[1]["name"] == "Bat Discharge"
 
 
+async def test_v1_4_battery_charge_price_is_negated(hass: HomeAssistant) -> None:
+    """Battery charge incentive price is negated during migration to represent an incentive."""
+    entry = MockConfigEntry(domain=DOMAIN, title="Hub", data={CONF_NAME: "Hub"})
+    entry.add_to_hass(hass)
+    hass.config_entries.async_update_entry(entry, minor_version=v1_3.MINOR_VERSION)
+
+    bat = _create_subentry(
+        {
+            CONF_ELEMENT_TYPE: battery.ELEMENT_TYPE,
+            CONF_NAME: "Bat",
+            CONF_CONNECTION: "bus",
+            SECTION_PRICING: {
+                CONF_PRICE_TARGET_SOURCE: {"type": "constant", "value": 0.01},
+            },
+        },
+        subentry_type=battery.ELEMENT_TYPE,
+    )
+    hass.config_entries.async_add_subentry(entry, bat)
+
+    assert await v1_4.async_migrate_entry(hass, entry) is True
+
+    policy_subs = [s for s in entry.subentries.values() if s.subentry_type == "policy"]
+    assert len(policy_subs) == 1
+    charge_rule = policy_subs[0].data[CONF_RULES][0]
+    assert charge_rule["name"] == "Bat Charge"
+    assert charge_rule["price"] == {"type": "constant", "value": -0.01}
+
+
+async def test_v1_4_battery_charge_entity_price_not_negated(hass: HomeAssistant) -> None:
+    """Battery charge with entity price type is preserved as-is (cannot negate at migration)."""
+    entry = MockConfigEntry(domain=DOMAIN, title="Hub", data={CONF_NAME: "Hub"})
+    entry.add_to_hass(hass)
+    hass.config_entries.async_update_entry(entry, minor_version=v1_3.MINOR_VERSION)
+
+    bat = _create_subentry(
+        {
+            CONF_ELEMENT_TYPE: battery.ELEMENT_TYPE,
+            CONF_NAME: "Bat",
+            CONF_CONNECTION: "bus",
+            SECTION_PRICING: {
+                CONF_PRICE_TARGET_SOURCE: {"type": "entity", "value": ["sensor.price"]},
+            },
+        },
+        subentry_type=battery.ELEMENT_TYPE,
+    )
+    hass.config_entries.async_add_subentry(entry, bat)
+
+    assert await v1_4.async_migrate_entry(hass, entry) is True
+
+    policy_subs = [s for s in entry.subentries.values() if s.subentry_type == "policy"]
+    assert len(policy_subs) == 1
+    charge_rule = policy_subs[0].data[CONF_RULES][0]
+    assert charge_rule["price"] == {"type": "entity", "value": ["sensor.price"]}
+
+
 @pytest.mark.parametrize(
     "pricing_value",
     [

--- a/custom_components/haeo/migrations/tests/test_v1_4.py
+++ b/custom_components/haeo/migrations/tests/test_v1_4.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from types import MappingProxyType
 from typing import Any
 
@@ -265,31 +266,41 @@ async def test_v1_4_battery_charge_price_is_negated(hass: HomeAssistant) -> None
     assert charge_rule["price"] == {"type": "constant", "value": -0.01}
 
 
-async def test_v1_4_battery_charge_entity_price_not_negated(hass: HomeAssistant) -> None:
+async def test_v1_4_battery_charge_entity_price_not_negated(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Battery charge with entity price type is preserved as-is (cannot negate at migration)."""
-    entry = MockConfigEntry(domain=DOMAIN, title="Hub", data={CONF_NAME: "Hub"})
-    entry.add_to_hass(hass)
-    hass.config_entries.async_update_entry(entry, minor_version=v1_3.MINOR_VERSION)
+    haeo_logger = logging.getLogger("custom_components.haeo")
+    haeo_logger.propagate = True
+    try:
+        with caplog.at_level(logging.WARNING, logger=v1_4.__name__):
+            entry = MockConfigEntry(domain=DOMAIN, title="Hub", data={CONF_NAME: "Hub"})
+            entry.add_to_hass(hass)
+            hass.config_entries.async_update_entry(entry, minor_version=v1_3.MINOR_VERSION)
 
-    bat = _create_subentry(
-        {
-            CONF_ELEMENT_TYPE: battery.ELEMENT_TYPE,
-            CONF_NAME: "Bat",
-            CONF_CONNECTION: "bus",
-            SECTION_PRICING: {
-                CONF_PRICE_TARGET_SOURCE: {"type": "entity", "value": ["sensor.price"]},
-            },
-        },
-        subentry_type=battery.ELEMENT_TYPE,
-    )
-    hass.config_entries.async_add_subentry(entry, bat)
+            bat = _create_subentry(
+                {
+                    CONF_ELEMENT_TYPE: battery.ELEMENT_TYPE,
+                    CONF_NAME: "Bat",
+                    CONF_CONNECTION: "bus",
+                    SECTION_PRICING: {
+                        CONF_PRICE_TARGET_SOURCE: {"type": "entity", "value": ["sensor.price"]},
+                    },
+                },
+                subentry_type=battery.ELEMENT_TYPE,
+            )
+            hass.config_entries.async_add_subentry(entry, bat)
 
-    assert await v1_4.async_migrate_entry(hass, entry) is True
+            assert await v1_4.async_migrate_entry(hass, entry) is True
 
-    policy_subs = [s for s in entry.subentries.values() if s.subentry_type == "policy"]
-    assert len(policy_subs) == 1
-    charge_rule = policy_subs[0].data[CONF_RULES][0]
-    assert charge_rule["price"] == {"type": "entity", "value": ["sensor.price"]}
+            policy_subs = [s for s in entry.subentries.values() if s.subentry_type == "policy"]
+            assert len(policy_subs) == 1
+            charge_rule = policy_subs[0].data[CONF_RULES][0]
+            assert charge_rule["price"] == {"type": "entity", "value": ["sensor.price"]}
+            assert "Cannot negate non-constant charge price" in caplog.text
+    finally:
+        haeo_logger.propagate = False
 
 
 @pytest.mark.parametrize(

--- a/custom_components/haeo/migrations/v1_4.py
+++ b/custom_components/haeo/migrations/v1_4.py
@@ -60,7 +60,8 @@ def _negate_price_value(price: dict[str, Any]) -> dict[str, Any]:
         return {**price, "value": -price["value"]}
     _LOGGER.warning(
         "Cannot negate non-constant charge price during migration; "
-        "value will be preserved as-is: %s",
+        "a positive entity price will behave as a cost in the new policy system. "
+        "To preserve incentive semantics, use a template sensor that outputs a negated value: %s",
         price,
     )
     return price

--- a/custom_components/haeo/migrations/v1_4.py
+++ b/custom_components/haeo/migrations/v1_4.py
@@ -48,6 +48,24 @@ def _policy_subentry(*, rules: list[dict[str, Any]]) -> dict[str, Any]:
     }
 
 
+def _negate_price_value(price: dict[str, Any]) -> dict[str, Any]:
+    """Negate a constant price value for charge incentive migration.
+
+    The old battery adapter produced a negative incentive internally. The new
+    policy system uses ``power * price * period`` where positive = cost, so the
+    stored positive value must be negated to preserve the original incentive
+    semantics.
+    """
+    if price.get("type") == "constant":
+        return {**price, "value": -price["value"]}
+    _LOGGER.warning(
+        "Cannot negate non-constant charge price during migration; "
+        "value will be preserved as-is: %s",
+        price,
+    )
+    return price
+
+
 def _extract_pricing_rules(subentry: ConfigSubentry) -> list[dict[str, Any]]:
     """Extract policy rules from an element's pricing section."""
     data = dict(subentry.data)
@@ -75,7 +93,7 @@ def _extract_pricing_rules(subentry: ConfigSubentry) -> list[dict[str, Any]]:
                 {
                     "name": f"{element_name} Charge",
                     "target": [element_name],
-                    "price": charge_price,
+                    "price": _negate_price_value(charge_price),
                 },
             )
 


### PR DESCRIPTION
Fixes the v1.4 migration producing charge rules with inverted economics — what should be an incentive to charge becomes a cost to charge.

## Problem

The old battery adapter produced a negative charge incentive internally via `_build_charge_early_incentive()` (`value * (ramp - 1.0)` → negative). The v1.4 migration preserved the positive stored value directly, but the new policy system uses `power × price × period` where positive = cost. A charge "incentive" of `0.01` became a `0.01` **cost** instead of a `-0.01` **incentive**.

## Fix

Added `_negate_price_value()` helper that:
- For `{"type": "constant", "value": X}`: returns `{"type": "constant", "value": -X}`
- For entity-type prices: returns unchanged with a warning log (cannot negate entity values at migration time)

Applied to charge rules in `_extract_pricing_rules()`.

## Testing

- `test_v1_4_battery_charge_price_is_negated` — constant price `0.01` → `-0.01`
- `test_v1_4_battery_charge_entity_price_not_negated` — entity prices preserved as-is
- All 11 migration tests pass