### PR TITLE
Expose list item sibling fields in input number extra state attributes

### DIFF
--- a/custom_components/haeo/entities/haeo_number.py
+++ b/custom_components/haeo/entities/haeo_number.py
@@ -167,17 +167,12 @@ class HaeoInputNumber(NumberEntity):
 
         # For list item fields, expose sibling fields from the list item
         if len(self._field_path) > 2:  # noqa: PLR2004
-            list_key, index_str, own_field = self._field_path[0], self._field_path[1], self._field_path[2]
-            try:
-                items = subentry.data.get(list_key)
-                if isinstance(items, (list, tuple)):
-                    item = items[int(index_str)]
-                    if isinstance(item, Mapping):
-                        for key, value in item.items():
-                            if key != own_field:
-                                self._base_extra_attrs[key] = value
-            except (ValueError, IndexError):
-                pass
+            own_field = self._field_path[2]
+            item = get_nested_config_value_by_path(subentry.data, self._field_path[:2])
+            if isinstance(item, Mapping):
+                for key, value in item.items():
+                    if key != own_field:
+                        self._base_extra_attrs[key] = value
 
         self._attr_extra_state_attributes = dict(self._base_extra_attrs)
 

--- a/custom_components/haeo/entities/haeo_number.py
+++ b/custom_components/haeo/entities/haeo_number.py
@@ -164,6 +164,21 @@ class HaeoInputNumber(NumberEntity):
             self._base_extra_attrs["source_entities"] = self._source_entity_ids
         if field_info.direction:
             self._base_extra_attrs["direction"] = field_info.direction
+
+        # For list item fields, expose sibling fields from the list item
+        if len(self._field_path) > 2:  # noqa: PLR2004
+            list_key, index_str, own_field = self._field_path[0], self._field_path[1], self._field_path[2]
+            try:
+                items = subentry.data.get(list_key)
+                if isinstance(items, (list, tuple)):
+                    item = items[int(index_str)]
+                    if isinstance(item, Mapping):
+                        for key, value in item.items():
+                            if key != own_field:
+                                self._base_extra_attrs[key] = value
+            except (ValueError, IndexError):
+                pass
+
         self._attr_extra_state_attributes = dict(self._base_extra_attrs)
 
         # Loaders for time series and scalar data

--- a/custom_components/haeo/entities/tests/test_haeo_number.py
+++ b/custom_components/haeo/entities/tests/test_haeo_number.py
@@ -361,6 +361,7 @@ async def test_list_item_sibling_fields_in_extra_state_attributes(
     )
 
     attrs = entity.extra_state_attributes
+    assert attrs is not None
     assert attrs["name"] == "Solar Export"
     assert attrs["source"] == ["Solar"]
     assert attrs["target"] == ["Grid"]

--- a/custom_components/haeo/entities/tests/test_haeo_number.py
+++ b/custom_components/haeo/entities/tests/test_haeo_number.py
@@ -310,6 +310,64 @@ async def test_nested_policy_rule_price_sets_rule_name_placeholder(
     assert entity._attr_translation_placeholders["rule_name"] == "Grid export fee"
 
 
+async def test_list_item_sibling_fields_in_extra_state_attributes(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    device_entry: Mock,
+    horizon_manager: Mock,
+) -> None:
+    """List item fields expose sibling fields from the same list item as extra state attributes."""
+    price_field = InputFieldInfo(
+        field_name="price",
+        entity_description=NumberEntityDescription(
+            key="price",
+            translation_key="policy_rule_price",
+            native_unit_of_measurement="USD/kWh",
+            native_min_value=-100.0,
+            native_max_value=100.0,
+            native_step=0.001,
+        ),
+        output_type=OutputType.PRICE,
+        time_series=True,
+    )
+    subentry = ConfigSubentry(
+        data=MappingProxyType(
+            {
+                "element_type": POLICY_ELEMENT_TYPE,
+                "name": "Policies",
+                CONF_RULES: [
+                    {
+                        "name": "Solar Export",
+                        "source": ["Solar"],
+                        "target": ["Grid"],
+                        "price": as_constant_value(0.02),
+                    },
+                ],
+            }
+        ),
+        subentry_type=POLICY_ELEMENT_TYPE,
+        title="Policies",
+        unique_id=None,
+    )
+    config_entry.runtime_data = None
+
+    entity = HaeoInputNumber(
+        config_entry=config_entry,
+        subentry=subentry,
+        field_info=price_field,
+        device_entry=device_entry,
+        horizon_manager=horizon_manager,
+        field_path=("rules", "0", "price"),
+    )
+
+    attrs = entity.extra_state_attributes
+    assert attrs["name"] == "Solar Export"
+    assert attrs["source"] == ["Solar"]
+    assert attrs["target"] == ["Grid"]
+    # The entity's own field should NOT be included
+    assert "price" not in attrs
+
+
 async def test_invalid_field_config_raises_runtime_error(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,


### PR DESCRIPTION
When an `HaeoInputNumber` represents a field inside a list item (e.g., a policy rule's price at path `("rules", "0", "price")`), it now generically exposes all sibling fields from that list item in `extra_state_attributes`.

## Problem

Policy price sensors had no context about which rule they belonged to — no source, target, or rule name in the state attributes. This made it hard to identify what each sensor controlled.

## Solution

Generic sibling extraction: if `field_path` has 3+ segments (indicating a list item field), extract the list item from subentry data and add all fields except the entity's own field to `_base_extra_attrs`. This works for any element type with list-based config, not just policies.

For a policy rule `{"name": "Solar Export", "source": ["Solar"], "target": ["Grid"], "price": {"type": "constant", "value": 0.02}}`, the price sensor's `extra_state_attributes` now includes `name`, `source`, and `target`.

## Testing

1 new test verifying sibling fields appear in attributes and the entity's own field is excluded. All 49 entity tests pass.