### PR TITLE
Filter policy source/target by element capability

### DIFF
--- a/custom_components/haeo/core/adapters/elements/battery.py
+++ b/custom_components/haeo/core/adapters/elements/battery.py
@@ -88,6 +88,8 @@ class BatteryAdapter:
     element_type: str = ELEMENT_TYPE
     advanced: bool = False
     connectivity: ConnectivityLevel = ConnectivityLevel.ADVANCED
+    can_source: bool = True
+    can_sink: bool = True
 
     def model_elements(self, config: BatteryConfigData) -> list[ModelElementConfig]:
         """Create model elements for Battery configuration.

--- a/custom_components/haeo/core/adapters/elements/battery_section.py
+++ b/custom_components/haeo/core/adapters/elements/battery_section.py
@@ -59,6 +59,8 @@ class BatterySectionAdapter:
     element_type: str = ELEMENT_TYPE
     advanced: bool = True
     connectivity: ConnectivityLevel = ConnectivityLevel.ADVANCED
+    can_source: bool = True
+    can_sink: bool = True
 
     def model_elements(self, config: BatterySectionConfigData) -> list[ModelElementConfig]:
         """Create model elements for BatterySection configuration.

--- a/custom_components/haeo/core/adapters/elements/connection.py
+++ b/custom_components/haeo/core/adapters/elements/connection.py
@@ -38,6 +38,8 @@ class ConnectionAdapter:
     element_type: str = ELEMENT_TYPE
     advanced: bool = True
     connectivity: ConnectivityLevel = ConnectivityLevel.NEVER
+    can_source: bool = False
+    can_sink: bool = False
 
     def model_elements(self, config: ConnectionConfigData) -> list[ModelElementConfig]:
         """Return model element parameters for Connection configuration."""

--- a/custom_components/haeo/core/adapters/elements/grid.py
+++ b/custom_components/haeo/core/adapters/elements/grid.py
@@ -68,6 +68,8 @@ class GridAdapter:
     element_type: str = ELEMENT_TYPE
     advanced: bool = False
     connectivity: ConnectivityLevel = ConnectivityLevel.ADVANCED
+    can_source: bool = True
+    can_sink: bool = True
 
     def model_elements(self, config: GridConfigData) -> list[ModelElementConfig]:
         """Create model elements for Grid configuration."""

--- a/custom_components/haeo/core/adapters/elements/inverter.py
+++ b/custom_components/haeo/core/adapters/elements/inverter.py
@@ -60,6 +60,8 @@ class InverterAdapter:
     element_type: str = ELEMENT_TYPE
     advanced: bool = False
     connectivity: ConnectivityLevel = ConnectivityLevel.ALWAYS
+    can_source: bool = False
+    can_sink: bool = False
 
     def model_elements(self, config: InverterConfigData) -> list[ModelElementConfig]:
         """Return model element parameters for Inverter configuration."""

--- a/custom_components/haeo/core/adapters/elements/load.py
+++ b/custom_components/haeo/core/adapters/elements/load.py
@@ -49,6 +49,8 @@ class LoadAdapter:
     element_type: str = ELEMENT_TYPE
     advanced: bool = False
     connectivity: ConnectivityLevel = ConnectivityLevel.ADVANCED
+    can_source: bool = False
+    can_sink: bool = True
 
     def model_elements(self, config: LoadConfigData) -> list[ModelElementConfig]:
         """Create model elements for Load configuration."""

--- a/custom_components/haeo/core/adapters/elements/node.py
+++ b/custom_components/haeo/core/adapters/elements/node.py
@@ -41,6 +41,8 @@ class NodeAdapter:
     element_type: str = ELEMENT_TYPE
     advanced: bool = True
     connectivity: ConnectivityLevel = ConnectivityLevel.ALWAYS
+    can_source: bool = True
+    can_sink: bool = True
 
     def model_elements(self, config: NodeConfigData) -> list[ModelElementConfig]:
         """Return model element parameters for Node configuration."""

--- a/custom_components/haeo/core/adapters/elements/policy.py
+++ b/custom_components/haeo/core/adapters/elements/policy.py
@@ -67,6 +67,8 @@ class PolicyAdapter:
     element_type: str = ELEMENT_TYPE
     advanced: bool = False
     connectivity: ConnectivityLevel = ConnectivityLevel.NEVER
+    can_source: bool = False
+    can_sink: bool = False
 
     def model_elements(self, config: PolicyConfigData) -> list[ModelElementConfig]:  # noqa: ARG002
         """Policy does not create model elements — policies are compiled separately."""

--- a/custom_components/haeo/core/adapters/elements/solar.py
+++ b/custom_components/haeo/core/adapters/elements/solar.py
@@ -46,6 +46,8 @@ class SolarAdapter:
     element_type: str = ELEMENT_TYPE
     advanced: bool = False
     connectivity: ConnectivityLevel = ConnectivityLevel.ADVANCED
+    can_source: bool = True
+    can_sink: bool = False
 
     def model_elements(self, config: SolarConfigData) -> list[ModelElementConfig]:
         """Return model element parameters for Solar configuration."""

--- a/custom_components/haeo/core/adapters/policy_compilation.py
+++ b/custom_components/haeo/core/adapters/policy_compilation.py
@@ -91,6 +91,12 @@ def compile_policies(
 
     names: set[str] = set(by_name.keys())
 
+    # Capability sets for wildcard expansion: nodes that can only produce
+    # should not appear as destinations, and nodes that can only consume
+    # should not appear as sources. Batteries default to both.
+    source_names = {name for name, elem in by_name.items() if elem.get("is_source", True)}
+    sink_names = {name for name, elem in by_name.items() if elem.get("is_sink", True)}
+
     conn_by_node: dict[str, list[ConnectionElementConfig]] = defaultdict(list)
     for conn in connections:
         conn_by_node[conn["source"]].append(conn)
@@ -104,8 +110,8 @@ def compile_policies(
     # --- Step 1: Flow enumeration ---
     flows: list[tuple[str, str, Any]] = []
     for policy in policy_configs:
-        sources = _resolve_wildcard(_as_name_list(policy.get("sources")), names)
-        destinations = _resolve_wildcard(_as_name_list(policy.get("destinations")), names)
+        sources = _resolve_wildcard(_as_name_list(policy.get("sources")), names, wildcard_set=source_names)
+        destinations = _resolve_wildcard(_as_name_list(policy.get("destinations")), names, wildcard_set=sink_names)
         price = policy.get("price")
         for src in sources:
             flows.extend((src, dst, price) for dst in destinations if src != dst)
@@ -187,8 +193,8 @@ def compile_policies(
 
     # --- Step 8: Pricing injection ---
     for policy in policy_configs:
-        sources = _resolve_wildcard(_as_name_list(policy.get("sources")), names)
-        destinations = _resolve_wildcard(_as_name_list(policy.get("destinations")), names)
+        sources = _resolve_wildcard(_as_name_list(policy.get("sources")), names, wildcard_set=source_names)
+        destinations = _resolve_wildcard(_as_name_list(policy.get("destinations")), names, wildcard_set=sink_names)
         price = policy.get("price")
         if price is None:
             continue
@@ -208,10 +214,20 @@ def compile_policies(
     return [*non_connections, *connections]
 
 
-def _resolve_wildcard(names: list[str], all_names: set[str]) -> list[str]:
-    """Resolve wildcard sources/destinations."""
+def _resolve_wildcard(
+    names: list[str],
+    all_names: set[str],
+    *,
+    wildcard_set: set[str] | None = None,
+) -> list[str]:
+    """Resolve wildcard sources/destinations.
+
+    When wildcard_set is provided, ["*"] expands to that set instead of
+    all_names. This filters wildcards to only capability-matching nodes
+    (e.g., sources that can actually produce power).
+    """
     if names == ["*"]:
-        return sorted(all_names)
+        return sorted(wildcard_set if wildcard_set is not None else all_names)
     return [n for n in names if n in all_names]
 
 

--- a/custom_components/haeo/core/adapters/registry.py
+++ b/custom_components/haeo/core/adapters/registry.py
@@ -33,6 +33,10 @@ class ElementAdapter(Protocol):
 
     connectivity: ConnectivityLevel
 
+    can_source: bool
+
+    can_sink: bool
+
     def model_elements(self, config: Any) -> list[ModelElementConfig]:
         """Return model element parameters for the loaded config."""
         ...

--- a/custom_components/haeo/core/adapters/tests/test_policy_compilation.py
+++ b/custom_components/haeo/core/adapters/tests/test_policy_compilation.py
@@ -115,10 +115,10 @@ def test_different_prices_separate() -> None:
 def test_wildcard_all_same_merges() -> None:
     """Wildcard source with single policy -> all sources get VLANs."""
     elements = [
-        _node("a"),
-        _node("b"),
-        _node("c"),
-        _node("d"),
+        _node("a", is_source=True),
+        _node("b", is_source=True),
+        _node("c", is_source=True),
+        _node("d", is_sink=True),
         _conn("c1", "a", "d"),
         _conn("c2", "b", "d"),
         _conn("c3", "c", "d"),
@@ -137,12 +137,60 @@ def test_no_policies_no_vlans() -> None:
 
 
 def test_node_without_policy_gets_outbound_tags() -> None:
-    """All nodes get outbound tags from the implicit allow-all rule."""
-    elements = [_node("grid"), _node("battery"), _node("load"), _conn("c1", "grid", "load")]
+    """All source-capable nodes get outbound tags from the implicit allow-all rule."""
+    elements = [
+        _node("grid", is_source=True),
+        _node("battery", is_source=True),
+        _node("load", is_sink=True),
+        _conn("c1", "grid", "load"),
+    ]
     policies = [{"sources": ["grid"], "destinations": ["load"], "price": 0.05}]
     result = compile_policies(elements, policies)
     battery = _find(result, "battery", element_type=MODEL_ELEMENT_TYPE_NODE)
     assert battery.get("outbound_tags") is not None
+
+
+def test_wildcard_excludes_sink_only_from_sources() -> None:
+    """Wildcard source expansion excludes nodes that can only consume."""
+    elements = [
+        _node("solar", is_source=True),
+        _node("load", is_sink=True),
+        _junction("sw"),
+        _conn("solar_sw", "solar", "sw"),
+        _conn("sw_load", "sw", "load"),
+    ]
+    policies = [{"sources": ["*"], "destinations": ["load"], "price": 0.05}]
+    result = compile_policies(elements, policies)
+    # Solar is a source — gets a VLAN
+    assert _outbound_tag(result, "solar") != 0
+    # Load is sink-only — not expanded as source, no outbound tag
+    load = _find(result, "load", element_type=MODEL_ELEMENT_TYPE_NODE)
+    assert load.get("outbound_tags") is None
+    # Junction is neither — not expanded as source, no outbound tag
+    sw = _find(result, "sw", element_type=MODEL_ELEMENT_TYPE_NODE)
+    assert sw.get("outbound_tags") is None
+
+
+def test_wildcard_excludes_source_only_from_destinations() -> None:
+    """Wildcard destination expansion excludes nodes that can only produce."""
+    elements = [
+        _node("grid", is_source=True, is_sink=True),
+        _node("solar", is_source=True),
+        _node("load", is_sink=True),
+        _conn("grid_load", "grid", "load"),
+        _conn("grid_solar", "grid", "solar"),
+    ]
+    policies = [{"sources": ["grid"], "destinations": ["*"], "price": 0.05}]
+    result = compile_policies(elements, policies)
+    # Load (sink) gets inbound tag from grid
+    load = _find(result, "load", element_type=MODEL_ELEMENT_TYPE_NODE)
+    assert load.get("inbound_tags") is not None
+    # Solar (source-only) is not a wildcard destination — no inbound tag from grid policy
+    solar = _find(result, "solar", element_type=MODEL_ELEMENT_TYPE_NODE)
+    solar_inbound = solar.get("inbound_tags")
+    grid_vlan = _outbound_tag(result, "grid")
+    # Grid's policy VLAN should not appear in solar's inbound tags
+    assert solar_inbound is None or grid_vlan not in solar_inbound
 
 
 # --- Reachability ---
@@ -198,12 +246,22 @@ def test_inbound_tags_set_on_destination() -> None:
 
 
 def test_routing_nodes_get_inbound_tags() -> None:
-    """Routing nodes get inbound tags from the implicit allow-all rule."""
-    elements = [_node("grid"), _junction("sw"), _node("load"), _conn("c1", "grid", "sw"), _conn("c2", "sw", "load")]
+    """Junctions (non-sinks) don't get inbound tags — they pass power through without consuming."""
+    elements = [
+        _node("grid", is_source=True),
+        _junction("sw"),
+        _node("load", is_sink=True),
+        _conn("c1", "grid", "sw"),
+        _conn("c2", "sw", "load"),
+    ]
     policies = [{"sources": ["grid"], "destinations": ["load"], "price": 0.05}]
     result = compile_policies(elements, policies)
     sw = _find(result, "sw", element_type=MODEL_ELEMENT_TYPE_NODE)
-    assert sw.get("inbound_tags") is not None
+    # Junction doesn't consume, so no inbound_tags needed
+    assert sw.get("inbound_tags") is None
+    # But load (the actual sink) does get inbound tags
+    load = _find(result, "load", element_type=MODEL_ELEMENT_TYPE_NODE)
+    assert load.get("inbound_tags") is not None
 
 
 # --- Default-allow ---
@@ -595,9 +653,22 @@ def test_compile_policies_without_connections_returns_unchanged() -> None:
     assert compile_policies(elements, policies) is elements
 
 
+def test_compile_policies_junctions_only_returns_unchanged() -> None:
+    """Wildcards that resolve to no source/sink nodes produce no flows."""
+    elements = [_junction("sw1"), _junction("sw2"), _conn("c1", "sw1", "sw2")]
+    policies = [{"sources": ["*"], "destinations": ["*"], "price": 0.05}]
+    result = compile_policies(elements, policies)
+    # No source or sink nodes, so wildcard expansion yields no flows — elements unchanged
+    assert result is elements
+
+
 def test_compile_policies_resolves_to_no_flows() -> None:
     """Unknown endpoint names resolve to no explicit flows but hidden rule still applies."""
-    elements = [_node("grid"), _node("load"), _conn("c1", "grid", "load")]
+    elements = [
+        _node("grid", is_source=True),
+        _node("load", is_sink=True),
+        _conn("c1", "grid", "load"),
+    ]
     policies = [{"sources": ["nosuch"], "destinations": ["alsomissing"], "price": 0.05}]
     result = compile_policies(elements, policies)
     # Hidden * -> * still generates VLANs for existing nodes
@@ -606,7 +677,11 @@ def test_compile_policies_resolves_to_no_flows() -> None:
 
 def test_compile_policies_non_list_endpoints_resolve_to_no_flows() -> None:
     """Non-list sources/destinations are ignored but hidden rule still applies."""
-    elements = [_node("grid"), _node("load"), _conn("c1", "grid", "load")]
+    elements = [
+        _node("grid", is_source=True),
+        _node("load", is_sink=True),
+        _conn("c1", "grid", "load"),
+    ]
     policies = [{"sources": "grid", "destinations": ("load",), "price": 0.05}]
     result = compile_policies(elements, policies)
     # Hidden * -> * still generates VLANs for existing nodes
@@ -616,9 +691,9 @@ def test_compile_policies_non_list_endpoints_resolve_to_no_flows() -> None:
 def test_wildcard_destination_tags_each_sources_paths() -> None:
     """Wildcard destination applies separate VLANs per source when signatures differ."""
     elements = [
-        _node("a"),
-        _node("b"),
-        _node("c"),
+        _node("a", is_source=True),
+        _node("b", is_source=True),
+        _node("c", is_sink=True),
         _conn("ac", "a", "c"),
         _conn("bc", "b", "c"),
     ]

--- a/custom_components/haeo/flows/elements/policy.py
+++ b/custom_components/haeo/flows/elements/policy.py
@@ -27,9 +27,12 @@ from homeassistant.helpers.selector import (
 )
 import voluptuous as vol
 
+from custom_components.haeo.core.adapters.registry import ELEMENT_TYPES
 from custom_components.haeo.core.const import CONF_ELEMENT_TYPE, CONF_NAME
 from custom_components.haeo.core.schema.constant_value import as_constant_value, is_constant_value
 from custom_components.haeo.core.schema.elements.element_type import ElementType
+from custom_components.haeo.core.schema.elements.node import CONF_IS_SINK, CONF_IS_SOURCE, SECTION_ROLE
+from custom_components.haeo.core.schema.elements.node import ELEMENT_TYPE as NODE_ELEMENT_TYPE
 from custom_components.haeo.core.schema.elements.policy import (
     CONF_ENABLED,
     CONF_PRICE,
@@ -94,8 +97,19 @@ class PolicySubentryFlowHandler(ElementFlowMixin, ConfigSubentryFlow):
         self._rules: list[PolicyRuleConfig] = []
         self._editing_index: int | None = None
 
-    def _get_participant_options(self) -> list[str]:
-        """Return all element names available as policy endpoints."""
+    def _get_participant_options(
+        self,
+        *,
+        can_source: bool = False,
+        can_sink: bool = False,
+    ) -> list[str]:
+        """Return element names available as policy endpoints.
+
+        Filters by adapter capability: only elements whose adapter declares
+        can_source (for source endpoints) or can_sink (for target endpoints)
+        are included. For Node elements, additionally checks instance-specific
+        role flags from the subentry data.
+        """
         hub_entry = self._get_entry()
         current_id = self._get_current_subentry_id()
 
@@ -109,8 +123,31 @@ class PolicySubentryFlowHandler(ElementFlowMixin, ConfigSubentryFlow):
             except (ValueError, KeyError):
                 continue
 
-            if element_type not in (ElementType.POLICY, ElementType.CONNECTION):
-                result.append(subentry.title)
+            adapter = ELEMENT_TYPES.get(element_type)
+            if adapter is None:
+                continue
+
+            if not adapter.can_source and not adapter.can_sink:
+                continue
+
+            # Node elements have instance-specific capabilities via role flags
+            if element_type == NODE_ELEMENT_TYPE:
+                role = subentry.data.get(SECTION_ROLE, {})
+                node_can_source = role.get(CONF_IS_SOURCE, False)
+                node_can_sink = role.get(CONF_IS_SINK, False)
+                if can_source and not node_can_source:
+                    continue
+                if can_sink and not node_can_sink:
+                    continue
+                if not node_can_source and not node_can_sink:
+                    continue
+            else:
+                if can_source and not adapter.can_source:
+                    continue
+                if can_sink and not adapter.can_sink:
+                    continue
+
+            result.append(subentry.title)
 
         return result
 
@@ -167,17 +204,22 @@ class PolicySubentryFlowHandler(ElementFlowMixin, ConfigSubentryFlow):
             )
         )
 
-    def _build_rule_schema(self, participants: list[str]) -> vol.Schema:
+    def _build_rule_schema(
+        self,
+        source_options: list[str],
+        target_options: list[str],
+    ) -> vol.Schema:
         """Build the schema for adding or editing a policy rule."""
-        endpoint_selector = self._build_endpoint_selector(participants)
+        source_selector = self._build_endpoint_selector(source_options)
+        target_selector = self._build_endpoint_selector(target_options)
         price_selector = self._build_price_selector()
 
         return vol.Schema(
             {
                 vol.Required(CONF_RULE_NAME): str,
                 vol.Required(CONF_ENABLED, default=True): BooleanSelector(BooleanSelectorConfig()),
-                vol.Optional(CONF_SOURCE): endpoint_selector,
-                vol.Optional(CONF_TARGET): endpoint_selector,
+                vol.Optional(CONF_SOURCE): source_selector,
+                vol.Optional(CONF_TARGET): target_selector,
                 vol.Optional(CONF_PRICE): price_selector,
             }
         )
@@ -298,7 +340,8 @@ class PolicySubentryFlowHandler(ElementFlowMixin, ConfigSubentryFlow):
         Otherwise creates a new Policies subentry.
         """
         errors: dict[str, str] = {}
-        participants = self._get_participant_options()
+        source_options = self._get_participant_options(can_source=True)
+        target_options = self._get_participant_options(can_sink=True)
 
         if user_input is not None:
             existing = self._find_existing_policy_subentry()
@@ -321,7 +364,7 @@ class PolicySubentryFlowHandler(ElementFlowMixin, ConfigSubentryFlow):
                     data=self._build_entry_data(),
                 )
 
-        schema = self._build_rule_schema(participants)
+        schema = self._build_rule_schema(source_options, target_options)
         if user_input is not None:
             schema = self.add_suggested_values_to_schema(schema, user_input)
 
@@ -374,7 +417,8 @@ class PolicySubentryFlowHandler(ElementFlowMixin, ConfigSubentryFlow):
     ) -> SubentryFlowResult:
         """Handle editing an existing policy rule."""
         errors: dict[str, str] = {}
-        participants = self._get_participant_options()
+        source_options = self._get_participant_options(can_source=True)
+        target_options = self._get_participant_options(can_sink=True)
         idx = self._editing_index
 
         if user_input is not None and self._validate_rule(
@@ -396,7 +440,7 @@ class PolicySubentryFlowHandler(ElementFlowMixin, ConfigSubentryFlow):
                     data=self._build_entry_data(),
                 )
 
-        schema = self._build_rule_schema(participants)
+        schema = self._build_rule_schema(source_options, target_options)
         if user_input is not None:
             defaults = user_input
         elif idx is not None and 0 <= idx < len(self._rules):

--- a/custom_components/haeo/flows/tests/test_policy_flows.py
+++ b/custom_components/haeo/flows/tests/test_policy_flows.py
@@ -15,6 +15,9 @@ from custom_components.haeo.const import CONF_INTEGRATION_TYPE, DOMAIN, INTEGRAT
 from custom_components.haeo.core.adapters.elements.policy import extract_policy_rules
 from custom_components.haeo.core.const import CONF_ELEMENT_TYPE, CONF_NAME
 from custom_components.haeo.core.schema.constant_value import as_constant_value
+from custom_components.haeo.core.schema.elements.inverter import ELEMENT_TYPE as INVERTER_ELEMENT_TYPE
+from custom_components.haeo.core.schema.elements.load import ELEMENT_TYPE as LOAD_ELEMENT_TYPE
+from custom_components.haeo.core.schema.elements.node import CONF_IS_SINK, CONF_IS_SOURCE, SECTION_ROLE
 from custom_components.haeo.core.schema.elements.node import ELEMENT_TYPE as NODE_ELEMENT_TYPE
 from custom_components.haeo.core.schema.elements.policy import (
     CONF_ENABLED,
@@ -26,6 +29,7 @@ from custom_components.haeo.core.schema.elements.policy import (
     PolicyRuleConfig,
 )
 from custom_components.haeo.core.schema.elements.policy import ELEMENT_TYPE as POLICY_ELEMENT_TYPE
+from custom_components.haeo.core.schema.elements.solar import ELEMENT_TYPE as SOLAR_ELEMENT_TYPE
 from custom_components.haeo.core.schema.entity_value import as_entity_value
 from custom_components.haeo.core.schema.none_value import as_none_value
 from custom_components.haeo.flows.elements.policy import (
@@ -51,9 +55,21 @@ def hub_entry(hass: HomeAssistant) -> MockConfigEntry:
     )
     entry.add_to_hass(hass)
 
-    for name in ("Solar", "Grid", "Battery", "Load"):
+    nodes = [
+        ("Solar", True, False),
+        ("Grid", True, True),
+        ("Battery", True, True),
+        ("Load", False, True),
+    ]
+    for name, is_source, is_sink in nodes:
         subentry = ConfigSubentry(
-            data=MappingProxyType({CONF_ELEMENT_TYPE: NODE_ELEMENT_TYPE, CONF_NAME: name}),
+            data=MappingProxyType(
+                {
+                    CONF_ELEMENT_TYPE: NODE_ELEMENT_TYPE,
+                    CONF_NAME: name,
+                    SECTION_ROLE: {CONF_IS_SOURCE: is_source, CONF_IS_SINK: is_sink},
+                }
+            ),
             subentry_type=NODE_ELEMENT_TYPE,
             title=name,
             unique_id=None,
@@ -560,6 +576,98 @@ def test_get_participant_options_skips_invalid_element_type_values(
     flow = _create_flow(hass, hub_entry)
     options = flow._get_participant_options()
     assert "Broken" not in options
+
+
+def test_get_participant_options_filters_source_capability(
+    hass: HomeAssistant,
+    hub_entry: MockConfigEntry,
+) -> None:
+    """Source filtering only returns elements whose adapter has can_source=True."""
+    # Add a load (sink-only) and solar (source-only) subentry
+    for name, etype in [("My Load", LOAD_ELEMENT_TYPE), ("My Solar", SOLAR_ELEMENT_TYPE)]:
+        subentry = ConfigSubentry(
+            data=MappingProxyType({CONF_ELEMENT_TYPE: etype, CONF_NAME: name}),
+            subentry_type=etype,
+            title=name,
+            unique_id=None,
+        )
+        hass.config_entries.async_add_subentry(hub_entry, subentry)
+
+    flow = _create_flow(hass, hub_entry)
+    source_options = flow._get_participant_options(can_source=True)
+    # Solar adapter has can_source=True
+    assert "My Solar" in source_options
+    # Load (sink-only) should be excluded
+    assert "My Load" not in source_options
+
+
+def test_get_participant_options_filters_sink_capability(
+    hass: HomeAssistant,
+    hub_entry: MockConfigEntry,
+) -> None:
+    """Sink filtering only returns elements whose adapter has can_sink=True."""
+    for name, etype in [("My Load", LOAD_ELEMENT_TYPE), ("My Solar", SOLAR_ELEMENT_TYPE)]:
+        subentry = ConfigSubentry(
+            data=MappingProxyType({CONF_ELEMENT_TYPE: etype, CONF_NAME: name}),
+            subentry_type=etype,
+            title=name,
+            unique_id=None,
+        )
+        hass.config_entries.async_add_subentry(hub_entry, subentry)
+
+    flow = _create_flow(hass, hub_entry)
+    target_options = flow._get_participant_options(can_sink=True)
+    # Load adapter has can_sink=True
+    assert "My Load" in target_options
+    # Solar (source-only) should be excluded
+    assert "My Solar" not in target_options
+
+
+def test_get_participant_options_excludes_passthrough_elements(
+    hass: HomeAssistant,
+    hub_entry: MockConfigEntry,
+) -> None:
+    """Elements with neither can_source nor can_sink (e.g., inverter) are excluded."""
+    inverter_subentry = ConfigSubentry(
+        data=MappingProxyType({CONF_ELEMENT_TYPE: INVERTER_ELEMENT_TYPE, CONF_NAME: "Inverter"}),
+        subentry_type=INVERTER_ELEMENT_TYPE,
+        title="Inverter",
+        unique_id=None,
+    )
+    hass.config_entries.async_add_subentry(hub_entry, inverter_subentry)
+
+    flow = _create_flow(hass, hub_entry)
+    # Inverter excluded from source options
+    assert "Inverter" not in flow._get_participant_options(can_source=True)
+    # Inverter excluded from sink options
+    assert "Inverter" not in flow._get_participant_options(can_sink=True)
+    # Inverter excluded from unfiltered options too (neither source nor sink)
+    assert "Inverter" not in flow._get_participant_options()
+
+
+def test_get_participant_options_excludes_junction_nodes(
+    hass: HomeAssistant,
+    hub_entry: MockConfigEntry,
+) -> None:
+    """Node elements with is_source=False and is_sink=False are excluded as junctions."""
+    junction_subentry = ConfigSubentry(
+        data=MappingProxyType(
+            {
+                CONF_ELEMENT_TYPE: NODE_ELEMENT_TYPE,
+                CONF_NAME: "Switchboard",
+                SECTION_ROLE: {CONF_IS_SOURCE: False, CONF_IS_SINK: False},
+            }
+        ),
+        subentry_type=NODE_ELEMENT_TYPE,
+        title="Switchboard",
+        unique_id=None,
+    )
+    hass.config_entries.async_add_subentry(hub_entry, junction_subentry)
+
+    flow = _create_flow(hass, hub_entry)
+    assert "Switchboard" not in flow._get_participant_options(can_source=True)
+    assert "Switchboard" not in flow._get_participant_options(can_sink=True)
+    assert "Switchboard" not in flow._get_participant_options()
 
 
 async def test_reconfigure_delete_invalid_index_keeps_rules_and_saves(

--- a/docs/developer-guide/policy-compilation.md
+++ b/docs/developer-guide/policy-compilation.md
@@ -33,7 +33,8 @@ graph TD
 ### Step 1: Flow enumeration
 
 Each policy expands into concrete `(source, destination, price_st, price_ts)` tuples.
-Wildcards (`*`) expand to all nodes.
+Wildcards (`*`) expand to capability-matching nodes only: source wildcards expand to
+nodes with `is_source=True`, and destination wildcards expand to nodes with `is_sink=True`.
 
 ### Step 2: Signature computation
 

--- a/docs/developer-guide/vlan-optimization.md
+++ b/docs/developer-guide/vlan-optimization.md
@@ -98,8 +98,8 @@ Policy 2: Solar -> Load: $0.05
 Policy: * -> Load: $0.05
 ```
 
-All sources get signature `{(Load,0.05,None)}`.
-All sources merge into VLAN 1.
+All source-capable nodes get signature `{(Load,0.05,None)}`.
+All source-capable nodes merge into VLAN 1.
 `K=2` regardless of node count.
 
 ## Complexity


### PR DESCRIPTION
Add `can_source` and `can_sink` metadata to element adapters and use it to filter policy configuration and VLAN assignment.

## Changes

### Adapter metadata
- Add `can_source` and `can_sink` to the `ElementAdapter` protocol
- Set on all adapter implementations:
  - Solar: source only
  - Load: sink only
  - Grid, Battery, Battery Section, Node: both
  - Inverter, Connection, Policy: neither (pass-through / non-participant)

### Policy flow filtering
- Source dropdown only shows elements with `can_source=True`
- Target dropdown only shows elements with `can_sink=True`
- Inverter (switchboard) is excluded from both since it's a pass-through junction

### VLAN optimization
- Wildcard `*` expansion in `compile_policies()` now respects `is_source`/`is_sink` flags on model nodes
- Source wildcards expand to source-capable nodes only
- Destination wildcards expand to sink-capable nodes only
- Produce-only nodes (e.g., Solar) no longer get destination VLANs
- Consume-only nodes (e.g., Load) no longer get source VLANs
- Junctions without source/sink capability don't get unnecessary VLANs

### Tests
- 2 new tests for wildcard source/sink filtering
- Updated 6 existing tests to set proper `is_source`/`is_sink` flags on test nodes
- Full suite: 1645 passed, 2 skipped