### PR TITLE
Fix policy edit defaults and require rule price

### DIFF
--- a/custom_components/haeo/core/schema/elements/policy.py
+++ b/custom_components/haeo/core/schema/elements/policy.py
@@ -60,6 +60,9 @@ class PolicyConfigSchema(TypedDict):
         list[PolicyRuleConfig],
         ListFieldHints(
             fields={
+                CONF_ENABLED: FieldHint(
+                    output_type=OutputType.STATUS,
+                ),
                 CONF_PRICE: FieldHint(
                     output_type=OutputType.PRICE,
                     time_series=True,

--- a/custom_components/haeo/elements/tests/test_get_list_input_fields.py
+++ b/custom_components/haeo/elements/tests/test_get_list_input_fields.py
@@ -3,7 +3,7 @@
 from custom_components.haeo.core.const import CONF_ELEMENT_TYPE
 from custom_components.haeo.core.schema.constant_value import as_constant_value
 from custom_components.haeo.core.schema.elements import ElementType
-from custom_components.haeo.core.schema.elements.policy import CONF_RULES
+from custom_components.haeo.core.schema.elements.policy import CONF_ENABLED, CONF_RULES
 from custom_components.haeo.elements import get_list_input_fields
 
 
@@ -28,9 +28,10 @@ def test_get_list_input_fields_builds_policy_rule_fields() -> None:
         CONF_ELEMENT_TYPE: ElementType.POLICY,
         "name": "Policies",
         CONF_RULES: [
-            {"name": "Export", "price": as_constant_value(0.05)},
+            {"name": "Export", CONF_ENABLED: True, "price": as_constant_value(0.05)},
         ],
     }
     groups = get_list_input_fields(cfg)
     assert f"{CONF_RULES}.0" in groups
+    assert CONF_ENABLED in groups[f"{CONF_RULES}.0"]
     assert "price" in groups[f"{CONF_RULES}.0"]

--- a/custom_components/haeo/entities/haeo_switch.py
+++ b/custom_components/haeo/entities/haeo_switch.py
@@ -129,6 +129,18 @@ class HaeoInputSwitch(SwitchEntity):
                 continue
             placeholders[key] = format_placeholder(value)
         placeholders.setdefault("name", subentry.title)
+
+        # For list item fields (e.g., rules.0.enabled), expose item name.
+        if len(self._field_path) > 1:
+            list_key, index_str, *_ = self._field_path
+            try:
+                items = subentry.data.get(list_key)
+                if isinstance(items, (list, tuple)):
+                    item = items[int(index_str)]
+                    if isinstance(item, Mapping) and "name" in item:
+                        placeholders["rule_name"] = str(item["name"])
+            except (ValueError, IndexError, KeyError):
+                pass
         self._attr_translation_placeholders = placeholders
 
         # Build base extra state attributes (static values)

--- a/custom_components/haeo/entities/tests/test_haeo_switch.py
+++ b/custom_components/haeo/entities/tests/test_haeo_switch.py
@@ -635,6 +635,81 @@ async def test_translation_placeholders_include_rule_name_for_list_field(
     assert placeholders.get("rule_name") == "Export"
 
 
+async def test_translation_placeholders_skip_invalid_list_index(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    device_entry: Mock,
+    horizon_manager: Mock,
+) -> None:
+    """Invalid list index in field_path does not raise and omits rule_name."""
+    field_info = InputFieldInfo(
+        field_name=CONF_ENABLED,
+        entity_description=SwitchEntityDescription(
+            key=CONF_ENABLED,
+            translation_key="policy_enabled",
+        ),
+        output_type=OutputType.STATUS,
+    )
+    subentry = ConfigSubentry(
+        data=MappingProxyType(
+            {
+                CONF_ELEMENT_TYPE: ElementType.POLICY,
+                CONF_NAME: "Policies",
+                CONF_RULES: [
+                    {"name": "Export", CONF_ENABLED: True},
+                ],
+            }
+        ),
+        subentry_type=ElementType.POLICY,
+        title="Policies",
+        unique_id=None,
+    )
+    config_entry.runtime_data = None
+
+    entity = HaeoInputSwitch(
+        config_entry=config_entry,
+        subentry=subentry,
+        field_info=field_info,
+        device_entry=device_entry,
+        horizon_manager=horizon_manager,
+        field_path=(CONF_RULES, "not-an-index", CONF_ENABLED),
+    )
+
+    placeholders = entity._attr_translation_placeholders
+    assert placeholders is not None
+    assert "rule_name" not in placeholders
+
+
+async def test_invalid_config_value_raises_runtime_error(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    device_entry: Mock,
+    curtailment_field_info: InputFieldInfo[SwitchEntityDescription],
+    horizon_manager: Mock,
+) -> None:
+    """Unknown switch config value types fail loudly."""
+    subentry = _create_subentry("Test Solar", {"allow_curtailment": True})
+    # Inject an invalid nested value shape for this field
+    invalid_data = dict(subentry.data)
+    invalid_data[SECTION_CURTAILMENT] = {curtailment_field_info.field_name: {"type": "invalid"}}
+    invalid_subentry = ConfigSubentry(
+        data=MappingProxyType(invalid_data),
+        subentry_type=subentry.subentry_type,
+        title=subentry.title,
+        unique_id=subentry.unique_id,
+    )
+    config_entry.runtime_data = None
+
+    with pytest.raises(RuntimeError, match="Invalid config value"):
+        HaeoInputSwitch(
+            config_entry=config_entry,
+            subentry=invalid_subentry,
+            field_info=curtailment_field_info,
+            device_entry=device_entry,
+            horizon_manager=horizon_manager,
+        )
+
+
 # --- Tests for horizon_start and get_values properties ---
 
 

--- a/custom_components/haeo/entities/tests/test_haeo_switch.py
+++ b/custom_components/haeo/entities/tests/test_haeo_switch.py
@@ -19,9 +19,11 @@ import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.haeo.const import CONF_RECORD_FORECASTS, DOMAIN
-from custom_components.haeo.core.const import CONF_NAME
+from custom_components.haeo.core.const import CONF_ELEMENT_TYPE, CONF_NAME
 from custom_components.haeo.core.model.const import OutputType
 from custom_components.haeo.core.schema import as_connection_target, as_constant_value, as_entity_value, as_none_value
+from custom_components.haeo.core.schema.elements import ElementType
+from custom_components.haeo.core.schema.elements.policy import CONF_ENABLED, CONF_RULES
 from custom_components.haeo.core.schema.elements.solar import CONF_FORECAST, SECTION_CURTAILMENT, SECTION_FORECAST
 from custom_components.haeo.core.schema.sections import CONF_CONNECTION
 from custom_components.haeo.elements.input_fields import InputFieldDefaults, InputFieldInfo
@@ -586,6 +588,51 @@ async def test_translation_key_defaults_to_field_name(
 
     # Field has no translation_key, so it uses field_name
     assert entity.entity_description.translation_key == "allow_curtailment"
+
+
+async def test_translation_placeholders_include_rule_name_for_list_field(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    device_entry: Mock,
+    horizon_manager: Mock,
+) -> None:
+    """List-based switch fields expose rule_name for translation placeholders."""
+    field_info = InputFieldInfo(
+        field_name=CONF_ENABLED,
+        entity_description=SwitchEntityDescription(
+            key=CONF_ENABLED,
+            translation_key="policy_enabled",
+        ),
+        output_type=OutputType.STATUS,
+    )
+    subentry = ConfigSubentry(
+        data=MappingProxyType(
+            {
+                CONF_ELEMENT_TYPE: ElementType.POLICY,
+                CONF_NAME: "Policies",
+                CONF_RULES: [
+                    {"name": "Export", CONF_ENABLED: True},
+                ],
+            }
+        ),
+        subentry_type=ElementType.POLICY,
+        title="Policies",
+        unique_id=None,
+    )
+    config_entry.runtime_data = None
+
+    entity = HaeoInputSwitch(
+        config_entry=config_entry,
+        subentry=subentry,
+        field_info=field_info,
+        device_entry=device_entry,
+        horizon_manager=horizon_manager,
+        field_path=(CONF_RULES, "0", CONF_ENABLED),
+    )
+
+    placeholders = entity._attr_translation_placeholders
+    assert placeholders is not None
+    assert placeholders.get("rule_name") == "Export"
 
 
 # --- Tests for horizon_start and get_values properties ---

--- a/custom_components/haeo/flows/elements/policy.py
+++ b/custom_components/haeo/flows/elements/policy.py
@@ -445,10 +445,8 @@ class PolicySubentryFlowHandler(ElementFlowMixin, ConfigSubentryFlow):
         source_options = self._get_participant_options(can_source=True)
         target_options = self._get_participant_options(can_sink=True)
         idx = self._editing_index
-        existing_rule_defaults: dict[str, Any] = {}
         existing_rule_input: dict[str, Any] = {}
         if idx is not None and 0 <= idx < len(self._rules):
-            existing_rule_defaults = self._rule_to_defaults(self._rules[idx])
             existing_rule_input = self._rule_to_edit_input(self._rules[idx])
 
         merged_input = {**existing_rule_input, **user_input} if user_input is not None else None

--- a/custom_components/haeo/flows/elements/policy.py
+++ b/custom_components/haeo/flows/elements/policy.py
@@ -44,7 +44,7 @@ from custom_components.haeo.core.schema.elements.policy import (
     PolicyRuleConfig,
 )
 from custom_components.haeo.core.schema.entity_value import as_entity_value, is_entity_value
-from custom_components.haeo.core.schema.none_value import as_none_value, is_none_value
+from custom_components.haeo.core.schema.none_value import is_none_value
 from custom_components.haeo.elements import get_list_input_fields
 from custom_components.haeo.elements.input_fields import InputFieldInfo
 from custom_components.haeo.flows.element_flow import ElementFlowMixin
@@ -170,11 +170,11 @@ class PolicySubentryFlowHandler(ElementFlowMixin, ConfigSubentryFlow):
         return section[CONF_PRICE]
 
     def _build_price_selector(self) -> NormalizingChooseSelector:
-        """Build a ChooseSelector for the price field (entity/constant/none)."""
+        """Build a ChooseSelector for the price field (entity/constant)."""
         field_info = self._get_price_field_info()
         return build_choose_selector(
             field_info,
-            allowed_choices={CHOICE_ENTITY, CHOICE_CONSTANT, CHOICE_NONE},
+            allowed_choices={CHOICE_ENTITY, CHOICE_CONSTANT},
             multiple=True,
             preferred_choice=CHOICE_CONSTANT,
         )
@@ -220,7 +220,7 @@ class PolicySubentryFlowHandler(ElementFlowMixin, ConfigSubentryFlow):
                 vol.Required(CONF_ENABLED, default=True): BooleanSelector(BooleanSelectorConfig()),
                 vol.Optional(CONF_SOURCE): source_selector,
                 vol.Optional(CONF_TARGET): target_selector,
-                vol.Optional(CONF_PRICE): price_selector,
+                vol.Required(CONF_PRICE): price_selector,
             }
         )
 
@@ -267,8 +267,6 @@ class PolicySubentryFlowHandler(ElementFlowMixin, ConfigSubentryFlow):
         if price is not None:
             if isinstance(price, list):
                 rule["price"] = as_entity_value(price)
-            elif isinstance(price, str) and price == "":
-                rule["price"] = as_none_value()
             elif isinstance(price, (int, float)):
                 rule["price"] = as_constant_value(float(price))
         return rule
@@ -290,9 +288,25 @@ class PolicySubentryFlowHandler(ElementFlowMixin, ConfigSubentryFlow):
             price = rule[CONF_PRICE]
             if is_constant_value(price) or is_entity_value(price):
                 defaults[CONF_PRICE] = price["value"]
-            elif is_none_value(price):
-                defaults[CONF_PRICE] = ""
         return defaults
+
+    def _rule_to_edit_input(self, rule: PolicyRuleConfig) -> dict[str, Any]:
+        """Convert a stored rule into parse-ready form input values."""
+        input_values: dict[str, Any] = {
+            CONF_RULE_NAME: rule["name"],
+            CONF_ENABLED: rule.get(CONF_ENABLED, True),
+            CONF_SOURCE: rule.get(CONF_SOURCE, ""),
+            CONF_TARGET: rule.get(CONF_TARGET, ""),
+        }
+
+        if CONF_PRICE in rule:
+            price = rule[CONF_PRICE]
+            if is_constant_value(price) or is_entity_value(price):
+                input_values[CONF_PRICE] = price["value"]
+            elif is_none_value(price):
+                input_values[CONF_PRICE] = ""
+
+        return input_values
 
     def _validate_rule(
         self,
@@ -316,6 +330,17 @@ class PolicySubentryFlowHandler(ElementFlowMixin, ConfigSubentryFlow):
         target = user_input.get(CONF_TARGET) or []
         if source and target and source == target:
             errors["base"] = "source_target_same"
+            return False
+
+        price = user_input.get(CONF_PRICE)
+        if isinstance(price, str) and price == "":
+            errors[CONF_PRICE] = "required"
+            return False
+        if price is None:
+            errors[CONF_PRICE] = "required"
+            return False
+        if isinstance(price, list) and not price:
+            errors[CONF_PRICE] = "required"
             return False
 
         return True
@@ -420,13 +445,20 @@ class PolicySubentryFlowHandler(ElementFlowMixin, ConfigSubentryFlow):
         source_options = self._get_participant_options(can_source=True)
         target_options = self._get_participant_options(can_sink=True)
         idx = self._editing_index
+        existing_rule_defaults: dict[str, Any] = {}
+        existing_rule_input: dict[str, Any] = {}
+        if idx is not None and 0 <= idx < len(self._rules):
+            existing_rule_defaults = self._rule_to_defaults(self._rules[idx])
+            existing_rule_input = self._rule_to_edit_input(self._rules[idx])
 
-        if user_input is not None and self._validate_rule(
-            user_input,
+        merged_input = {**existing_rule_input, **user_input} if user_input is not None else None
+
+        if merged_input is not None and self._validate_rule(
+            merged_input,
             errors,
             exclude_index=idx,
         ):
-            rule = self._parse_rule_input(user_input)
+            rule = self._parse_rule_input(merged_input)
             if idx is not None and 0 <= idx < len(self._rules):
                 self._rules[idx] = rule
             self._editing_index = None

--- a/custom_components/haeo/flows/elements/policy.py
+++ b/custom_components/haeo/flows/elements/policy.py
@@ -471,8 +471,8 @@ class PolicySubentryFlowHandler(ElementFlowMixin, ConfigSubentryFlow):
                 )
 
         schema = self._build_rule_schema(source_options, target_options)
-        if user_input is not None:
-            defaults = user_input
+        if merged_input is not None:
+            defaults = merged_input
         elif idx is not None and 0 <= idx < len(self._rules):
             defaults = self._rule_to_defaults(self._rules[idx])
         else:

--- a/custom_components/haeo/flows/tests/test_policy_flows.py
+++ b/custom_components/haeo/flows/tests/test_policy_flows.py
@@ -484,6 +484,69 @@ async def test_edit_rule_preserves_source_target_when_omitted_from_submission(
     assert update_data[CONF_RULES][0]["price"] == as_constant_value(0.03)
 
 
+async def test_edit_rule_updates_only_selected_rule_without_losing_others(
+    hass: HomeAssistant,
+    hub_entry: MockConfigEntry,
+) -> None:
+    """Editing one rule preserves all other rules and total rule count."""
+    existing_rules: list[PolicyRuleConfig] = [
+        {
+            "name": "Rule A",
+            "source": ["Solar"],
+            "target": ["Grid"],
+            "price": as_constant_value(0.02),
+        },
+        {
+            "name": "Rule B",
+            "source": ["Grid"],
+            "target": ["Battery"],
+            "price": as_constant_value(0.05),
+        },
+        {
+            "name": "Rule C",
+            "source": ["Battery"],
+            "target": ["Load"],
+            "price": as_constant_value(0.01),
+        },
+    ]
+    subentry = _make_policy_subentry(existing_rules)
+    hass.config_entries.async_add_subentry(hub_entry, subentry)
+
+    flow = _create_flow(hass, hub_entry)
+    flow.context = {"subentry_id": subentry.subentry_id}
+    flow._get_reconfigure_subentry = Mock(return_value=subentry)
+    flow.async_update_and_abort = Mock(
+        return_value={"type": FlowResultType.ABORT, "reason": "reconfigure_successful"},
+    )
+
+    await flow.async_step_reconfigure(user_input=None)
+    await flow.async_step_reconfigure(
+        user_input={
+            CONF_RULE: "1",
+            CONF_ACTION: ACTION_EDIT,
+        }
+    )
+
+    result = await flow.async_step_edit_rule(
+        user_input={
+            CONF_RULE_NAME: "Rule B Updated",
+            CONF_ENABLED: True,
+            CONF_PRICE: 0.07,
+        }
+    )
+
+    assert result.get("type") == FlowResultType.ABORT
+    update_data = flow.async_update_and_abort.call_args.kwargs["data"]
+    rules = update_data[CONF_RULES]
+    assert len(rules) == 3
+    assert rules[0] == existing_rules[0]
+    assert rules[2] == existing_rules[2]
+    assert rules[1]["name"] == "Rule B Updated"
+    assert rules[1]["source"] == ["Grid"]
+    assert rules[1]["target"] == ["Battery"]
+    assert rules[1]["price"] == as_constant_value(0.07)
+
+
 async def test_edit_rule_rejects_duplicate_name(
     hass: HomeAssistant,
     hub_entry: MockConfigEntry,
@@ -528,6 +591,78 @@ async def test_edit_rule_rejects_duplicate_name(
 
     assert result.get("type") == FlowResultType.FORM
     assert result.get("errors") == {CONF_RULE_NAME: "name_exists"}
+
+
+async def test_edit_rule_saved_values_restore_when_reopened(
+    hass: HomeAssistant,
+    hub_entry: MockConfigEntry,
+) -> None:
+    """Saved rule edits appear as defaults when opening edit again."""
+    existing_rules: list[PolicyRuleConfig] = [
+        {
+            "name": "Solar Export",
+            "source": ["Solar"],
+            "target": ["Grid"],
+            "price": as_constant_value(0.02),
+        },
+    ]
+    subentry = _make_policy_subentry(existing_rules)
+    hass.config_entries.async_add_subentry(hub_entry, subentry)
+
+    # First edit/save pass
+    save_flow = _create_flow(hass, hub_entry)
+    save_flow.context = {"subentry_id": subentry.subentry_id}
+    save_flow._get_reconfigure_subentry = Mock(return_value=subentry)
+    save_flow.async_update_and_abort = Mock(
+        return_value={"type": FlowResultType.ABORT, "reason": "reconfigure_successful"},
+    )
+
+    await save_flow.async_step_reconfigure(user_input=None)
+    await save_flow.async_step_reconfigure(
+        user_input={
+            CONF_RULE: "0",
+            CONF_ACTION: ACTION_EDIT,
+        }
+    )
+    await save_flow.async_step_edit_rule(
+        user_input={
+            CONF_RULE_NAME: "Solar Export Updated",
+            CONF_ENABLED: True,
+            CONF_SOURCE: ["Solar"],
+            CONF_TARGET: ["Battery"],
+            CONF_PRICE: 0.06,
+        }
+    )
+
+    saved_data = save_flow.async_update_and_abort.call_args.kwargs["data"]
+    saved_subentry = _make_policy_subentry(saved_data[CONF_RULES])
+    hass.config_entries.async_add_subentry(hub_entry, saved_subentry)
+
+    # Re-open edit using saved values
+    reopen_flow = _create_flow(hass, hub_entry)
+    reopen_flow.context = {"subentry_id": saved_subentry.subentry_id}
+    reopen_flow._get_reconfigure_subentry = Mock(return_value=saved_subentry)
+    reopen_flow._get_subentry = Mock(return_value=saved_subentry)
+
+    await reopen_flow.async_step_reconfigure(user_input=None)
+    await reopen_flow.async_step_reconfigure(
+        user_input={
+            CONF_RULE: "0",
+            CONF_ACTION: ACTION_EDIT,
+        }
+    )
+    reopen_result = await reopen_flow.async_step_edit_rule(user_input=None)
+
+    assert _get_suggested_value(reopen_result, CONF_RULE_NAME) == "Solar Export Updated"
+    assert _get_suggested_value(reopen_result, CONF_SOURCE) == {
+        "active_choice": CHOICE_ELEMENTS,
+        CHOICE_ELEMENTS: ["Solar"],
+    }
+    assert _get_suggested_value(reopen_result, CONF_TARGET) == {
+        "active_choice": CHOICE_ELEMENTS,
+        CHOICE_ELEMENTS: ["Battery"],
+    }
+    assert _get_suggested_value(reopen_result, CONF_PRICE) == 0.06
 
 
 async def test_edit_rule_rejects_duplicate_name_preserves_omitted_source_target_defaults(

--- a/custom_components/haeo/flows/tests/test_policy_flows.py
+++ b/custom_components/haeo/flows/tests/test_policy_flows.py
@@ -31,6 +31,8 @@ from custom_components.haeo.core.schema.elements.policy import (
 from custom_components.haeo.core.schema.elements.policy import ELEMENT_TYPE as POLICY_ELEMENT_TYPE
 from custom_components.haeo.core.schema.elements.solar import ELEMENT_TYPE as SOLAR_ELEMENT_TYPE
 from custom_components.haeo.core.schema.entity_value import as_entity_value
+from custom_components.haeo.core.schema.none_value import as_none_value
+from custom_components.haeo.flows.elements import policy as policy_flow
 from custom_components.haeo.flows.elements.policy import (
     ACTION_DELETE,
     ACTION_EDIT,
@@ -528,6 +530,54 @@ async def test_edit_rule_rejects_duplicate_name(
     assert result.get("errors") == {CONF_RULE_NAME: "name_exists"}
 
 
+async def test_edit_rule_rejects_duplicate_name_preserves_omitted_source_target_defaults(
+    hass: HomeAssistant,
+    hub_entry: MockConfigEntry,
+) -> None:
+    """Validation errors keep previous source/target defaults when omitted from submission."""
+    existing_rules: list[PolicyRuleConfig] = [
+        {
+            "name": "Solar Export",
+            "source": ["Solar"],
+            "target": ["Grid"],
+            "price": as_constant_value(0.02),
+        },
+        {
+            "name": "Grid Charge",
+            "source": ["Grid"],
+            "target": ["Battery"],
+            "price": as_constant_value(0.05),
+        },
+    ]
+    subentry = _make_policy_subentry(existing_rules)
+    hass.config_entries.async_add_subentry(hub_entry, subentry)
+
+    flow = _create_flow(hass, hub_entry)
+    flow.context = {"subentry_id": subentry.subentry_id}
+    flow._get_reconfigure_subentry = Mock(return_value=subentry)
+
+    await flow.async_step_reconfigure(user_input=None)
+    await flow.async_step_reconfigure(
+        user_input={
+            CONF_RULE: "0",
+            CONF_ACTION: ACTION_EDIT,
+        }
+    )
+
+    result = await flow.async_step_edit_rule(
+        user_input={
+            CONF_RULE_NAME: "Grid Charge",
+            CONF_ENABLED: True,
+            CONF_PRICE: 0.03,
+        }
+    )
+
+    assert result.get("type") == FlowResultType.FORM
+    assert result.get("errors") == {CONF_RULE_NAME: "name_exists"}
+    assert _get_suggested_value(result, CONF_SOURCE) == ["Solar"]
+    assert _get_suggested_value(result, CONF_TARGET) == ["Grid"]
+
+
 def test_endpoint_selector_normalizes_wildcard_and_node_lists(
     hass: HomeAssistant,
     hub_entry: MockConfigEntry,
@@ -608,6 +658,17 @@ def test_endpoint_selector_delegates_to_super_without_active_choice(
         sel({"unexpected": "shape"})
 
 
+def test_endpoint_selector_unknown_active_choice_delegates_to_super(
+    hass: HomeAssistant,
+    hub_entry: MockConfigEntry,
+) -> None:
+    """Unknown active_choice values are delegated to base selector validation."""
+    flow = _create_flow(hass, hub_entry)
+    sel = flow._build_endpoint_selector(["Solar"])
+    with pytest.raises(vol.Invalid):
+        sel({"active_choice": "unknown"})
+
+
 def test_get_participant_options_skips_invalid_element_type_values(
     hass: HomeAssistant,
     hub_entry: MockConfigEntry,
@@ -624,6 +685,29 @@ def test_get_participant_options_skips_invalid_element_type_values(
     flow = _create_flow(hass, hub_entry)
     options = flow._get_participant_options()
     assert "Broken" not in options
+
+
+def test_get_participant_options_skips_subentries_without_registered_adapter(
+    hass: HomeAssistant,
+    hub_entry: MockConfigEntry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Subentries with missing adapter registrations are ignored."""
+    subentry = ConfigSubentry(
+        data=MappingProxyType({CONF_ELEMENT_TYPE: SOLAR_ELEMENT_TYPE, CONF_NAME: "SolarNoAdapter"}),
+        subentry_type=SOLAR_ELEMENT_TYPE,
+        title="SolarNoAdapter",
+        unique_id=None,
+    )
+    hass.config_entries.async_add_subentry(hub_entry, subentry)
+
+    patched = dict(policy_flow.ELEMENT_TYPES)
+    patched.pop(SOLAR_ELEMENT_TYPE, None)
+    monkeypatch.setattr(policy_flow, "ELEMENT_TYPES", patched)
+
+    flow = _create_flow(hass, hub_entry)
+    options = flow._get_participant_options(can_source=True)
+    assert "SolarNoAdapter" not in options
 
 
 def test_get_participant_options_filters_source_capability(
@@ -754,6 +838,38 @@ async def test_reconfigure_delete_invalid_index_keeps_rules_and_saves(
     assert update_data[CONF_RULES] == existing_rules
 
 
+async def test_reconfigure_edit_invalid_index_shows_form(
+    hass: HomeAssistant,
+    hub_entry: MockConfigEntry,
+) -> None:
+    """Selecting edit with an invalid index keeps reconfigure form open."""
+    existing_rules: list[PolicyRuleConfig] = [
+        {
+            "name": "Solar Export",
+            "source": ["Solar"],
+            "target": ["Grid"],
+            "price": as_constant_value(0.02),
+        },
+    ]
+    subentry = _make_policy_subentry(existing_rules)
+    hass.config_entries.async_add_subentry(hub_entry, subentry)
+
+    flow = _create_flow(hass, hub_entry)
+    flow.context = {"subentry_id": subentry.subentry_id}
+    flow._get_reconfigure_subentry = Mock(return_value=subentry)
+
+    await flow.async_step_reconfigure(user_input=None)
+    result = await flow.async_step_reconfigure(
+        user_input={
+            CONF_RULE: "5",
+            CONF_ACTION: ACTION_EDIT,
+        }
+    )
+
+    assert result.get("type") == FlowResultType.FORM
+    assert result.get("step_id") == "reconfigure"
+
+
 async def test_edit_rule_valid_input_without_subentry_returns_form(
     hass: HomeAssistant,
     hub_entry: MockConfigEntry,
@@ -769,6 +885,28 @@ async def test_edit_rule_valid_input_without_subentry_returns_form(
             CONF_RULE_NAME: "Renamed",
             CONF_ENABLED: True,
             CONF_PRICE: 0.01,
+        }
+    )
+
+    assert result.get("type") == FlowResultType.FORM
+    assert result.get("step_id") == "edit_rule"
+
+
+async def test_edit_rule_valid_input_with_invalid_index_returns_form(
+    hass: HomeAssistant,
+    hub_entry: MockConfigEntry,
+) -> None:
+    """Valid edit submission with invalid index keeps form open."""
+    flow = _create_flow(hass, hub_entry)
+    flow._rules = [{"name": "Existing", "price": as_constant_value(0.01)}]
+    flow._editing_index = 99
+    flow._get_subentry = Mock(return_value=None)
+
+    result = await flow.async_step_edit_rule(
+        user_input={
+            CONF_RULE_NAME: "Renamed",
+            CONF_ENABLED: True,
+            CONF_PRICE: 0.02,
         }
     )
 
@@ -988,6 +1126,20 @@ def test_rule_to_defaults_enabled_always_present() -> None:
     assert defaults_disabled[CONF_ENABLED] is False
 
 
+def test_rule_to_defaults_ignores_legacy_none_price() -> None:
+    """Legacy none pricing does not add a price default."""
+    flow = PolicySubentryFlowHandler()
+    defaults = flow._rule_to_defaults({"name": "Test", "price": as_none_value()})
+    assert CONF_PRICE not in defaults
+
+
+def test_rule_to_edit_input_maps_legacy_none_price_to_empty_string() -> None:
+    """Legacy none pricing maps to empty string for form-compatible merged input."""
+    flow = PolicySubentryFlowHandler()
+    input_values = flow._rule_to_edit_input({"name": "Test", "price": as_none_value()})
+    assert input_values[CONF_PRICE] == ""
+
+
 def test_parse_rule_input_stores_enabled() -> None:
     """Enabled field is always stored in the rule."""
     flow = PolicySubentryFlowHandler()
@@ -996,3 +1148,26 @@ def test_parse_rule_input_stores_enabled() -> None:
 
     rule_disabled = flow._parse_rule_input({CONF_RULE_NAME: "Test", CONF_ENABLED: False})
     assert rule_disabled.get("enabled") is False
+
+
+@pytest.mark.parametrize(
+    "price_input",
+    [
+        None,
+        [],
+    ],
+)
+def test_validate_rule_requires_non_empty_price(price_input: Any) -> None:
+    """Rule validation rejects missing or empty list price input."""
+    flow = PolicySubentryFlowHandler()
+    errors: dict[str, str] = {}
+    valid = flow._validate_rule(
+        {
+            CONF_RULE_NAME: "Test",
+            CONF_ENABLED: True,
+            CONF_PRICE: price_input,
+        },
+        errors,
+    )
+    assert not valid
+    assert errors == {CONF_PRICE: "required"}

--- a/custom_components/haeo/flows/tests/test_policy_flows.py
+++ b/custom_components/haeo/flows/tests/test_policy_flows.py
@@ -31,7 +31,6 @@ from custom_components.haeo.core.schema.elements.policy import (
 from custom_components.haeo.core.schema.elements.policy import ELEMENT_TYPE as POLICY_ELEMENT_TYPE
 from custom_components.haeo.core.schema.elements.solar import ELEMENT_TYPE as SOLAR_ELEMENT_TYPE
 from custom_components.haeo.core.schema.entity_value import as_entity_value
-from custom_components.haeo.core.schema.none_value import as_none_value
 from custom_components.haeo.flows.elements.policy import (
     ACTION_DELETE,
     ACTION_EDIT,
@@ -437,6 +436,52 @@ async def test_edit_rule_updates_and_saves(
     assert update_data[CONF_RULES][0]["price"] == as_constant_value(0.03)
 
 
+async def test_edit_rule_preserves_source_target_when_omitted_from_submission(
+    hass: HomeAssistant,
+    hub_entry: MockConfigEntry,
+) -> None:
+    """Editing a rule without source/target keeps the existing endpoint values."""
+    existing_rules: list[PolicyRuleConfig] = [
+        {
+            "name": "Solar Export",
+            "source": ["Solar"],
+            "target": ["Grid"],
+            "price": as_constant_value(0.02),
+        },
+    ]
+    subentry = _make_policy_subentry(existing_rules)
+    hass.config_entries.async_add_subentry(hub_entry, subentry)
+
+    flow = _create_flow(hass, hub_entry)
+    flow.context = {"subentry_id": subentry.subentry_id}
+    flow._get_reconfigure_subentry = Mock(return_value=subentry)
+    flow.async_update_and_abort = Mock(
+        return_value={"type": FlowResultType.ABORT, "reason": "reconfigure_successful"},
+    )
+
+    await flow.async_step_reconfigure(user_input=None)
+    await flow.async_step_reconfigure(
+        user_input={
+            CONF_RULE: "0",
+            CONF_ACTION: ACTION_EDIT,
+        }
+    )
+
+    result = await flow.async_step_edit_rule(
+        user_input={
+            CONF_RULE_NAME: "Solar Export Updated",
+            CONF_ENABLED: True,
+            CONF_PRICE: 0.03,
+        }
+    )
+
+    assert result.get("type") == FlowResultType.ABORT
+    update_data = flow.async_update_and_abort.call_args.kwargs["data"]
+    assert update_data[CONF_RULES][0]["source"] == ["Solar"]
+    assert update_data[CONF_RULES][0]["target"] == ["Grid"]
+    assert update_data[CONF_RULES][0]["price"] == as_constant_value(0.03)
+
+
 async def test_edit_rule_rejects_duplicate_name(
     hass: HomeAssistant,
     hub_entry: MockConfigEntry,
@@ -494,17 +539,20 @@ def test_endpoint_selector_normalizes_wildcard_and_node_lists(
     assert sel({"active_choice": CHOICE_ELEMENTS, CHOICE_ELEMENTS: ["Solar"]}) == ["Solar"]
 
 
-def test_parse_rule_input_empty_string_price_becomes_none_value() -> None:
-    """Empty price string in the form is stored as explicit none pricing."""
+def test_parse_rule_input_empty_string_price_is_rejected() -> None:
+    """Empty price is rejected because policy price is required."""
     flow = PolicySubentryFlowHandler()
-    rule = flow._parse_rule_input(
+    errors: dict[str, str] = {}
+    valid = flow._validate_rule(
         {
             CONF_RULE_NAME: "Free flow",
             CONF_ENABLED: True,
             CONF_PRICE: "",
-        }
+        },
+        errors,
     )
-    assert rule.get("price") == as_none_value()
+    assert not valid
+    assert errors == {CONF_PRICE: "required"}
 
 
 def test_parse_rule_input_list_price_becomes_entity_value() -> None:
@@ -928,33 +976,6 @@ def test_endpoint_selector_empty_elements_raises_invalid(
     sel = flow._build_endpoint_selector(["Solar", "Grid"])
     with pytest.raises(vol.Invalid):
         sel({"active_choice": CHOICE_ELEMENTS, CHOICE_ELEMENTS: []})
-
-
-async def test_edit_rule_shows_previous_none_price(
-    hass: HomeAssistant,
-    hub_entry: MockConfigEntry,
-) -> None:
-    """Editing a rule with none price pre-fills empty string."""
-    existing_rules: list[PolicyRuleConfig] = [
-        {
-            "name": "Free Flow",
-            "price": as_none_value(),
-        },
-    ]
-    subentry = _make_policy_subentry(existing_rules)
-    hass.config_entries.async_add_subentry(hub_entry, subentry)
-
-    flow = _create_flow(hass, hub_entry)
-    flow.context = {"subentry_id": subentry.subentry_id}
-    flow._get_reconfigure_subentry = Mock(return_value=subentry)
-    flow._get_subentry = Mock(return_value=subentry)
-
-    await flow.async_step_reconfigure(user_input=None)
-    await flow.async_step_reconfigure(user_input={CONF_RULE: "0", CONF_ACTION: ACTION_EDIT})
-
-    result = await flow.async_step_edit_rule(user_input=None)
-
-    assert _get_suggested_value(result, CONF_PRICE) == ""
 
 
 def test_rule_to_defaults_enabled_always_present() -> None:

--- a/custom_components/haeo/switch.py
+++ b/custom_components/haeo/switch.py
@@ -12,6 +12,7 @@ from custom_components.haeo.core.const import CONF_ELEMENT_TYPE
 from custom_components.haeo.core.schema import is_none_value
 from custom_components.haeo.elements import (
     get_input_fields,
+    get_list_input_fields,
     get_nested_config_value_by_path,
     is_element_config_schema,
     iter_input_field_paths,
@@ -54,12 +55,14 @@ async def async_setup_entry(
 
         # Get input field definitions for this element type
         input_fields = get_input_fields(element_config)
+        list_input_fields = get_list_input_fields(element_config)
+        all_fields = {**input_fields, **list_input_fields}
 
         # Filter to only switch fields (by entity description class name)
         # Note: isinstance doesn't work due to Home Assistant's frozen_dataclass_compat wrapper
         switch_fields = [
             (field_path, field_info)
-            for field_path, field_info in iter_input_field_paths(input_fields)
+            for field_path, field_info in iter_input_field_paths(all_fields)
             if type(field_info.entity_description).__name__ == "SwitchEntityDescription"
         ]
 

--- a/custom_components/haeo/tests/test_switch.py
+++ b/custom_components/haeo/tests/test_switch.py
@@ -23,6 +23,11 @@ from custom_components.haeo.core.schema.elements.grid import (
     SECTION_PRICING,
 )
 from custom_components.haeo.core.schema.elements.grid import ELEMENT_TYPE as GRID_TYPE
+from custom_components.haeo.core.schema.elements.policy import (
+    CONF_ENABLED as CONF_POLICY_ENABLED,
+    CONF_RULES,
+)
+from custom_components.haeo.core.schema.elements.policy import ELEMENT_TYPE as POLICY_TYPE
 from custom_components.haeo.core.schema.elements.solar import (
     CONF_CURTAILMENT,
     CONF_FORECAST,
@@ -277,6 +282,39 @@ async def test_setup_creates_switch_entities_for_solar_curtailment(
         # Check if any switch entity was created for curtailment
         field_names = {e._field_info.field_name for e in input_switches}
         assert CONF_CURTAILMENT in field_names
+
+
+async def test_setup_creates_switch_entities_for_policy_rule_enabled(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Setup creates policy enabled switches from list-based rule fields."""
+    _add_subentry(hass, config_entry, ELEMENT_TYPE_NETWORK, "Test Network", {})
+    _add_subentry(
+        hass,
+        config_entry,
+        POLICY_TYPE,
+        "Policies",
+        {
+            CONF_RULES: [
+                {
+                    "name": "Export policy",
+                    CONF_POLICY_ENABLED: True,
+                    "price": as_constant_value(0.05),
+                }
+            ]
+        },
+    )
+
+    async_add_entities = Mock()
+    await async_setup_entry(hass, config_entry, async_add_entities)
+
+    assert async_add_entities.called
+    entities = list(async_add_entities.call_args.args[0])
+    input_switches = [e for e in entities if hasattr(e, "_field_info")]
+    enabled_switches = [e for e in input_switches if e._field_info.field_name == CONF_POLICY_ENABLED]
+    assert enabled_switches
+    assert enabled_switches[0]._field_path == (CONF_RULES, "0", CONF_POLICY_ENABLED)
 
 
 async def test_setup_creates_correct_device_identifiers(

--- a/custom_components/haeo/tests/test_switch.py
+++ b/custom_components/haeo/tests/test_switch.py
@@ -23,10 +23,8 @@ from custom_components.haeo.core.schema.elements.grid import (
     SECTION_PRICING,
 )
 from custom_components.haeo.core.schema.elements.grid import ELEMENT_TYPE as GRID_TYPE
-from custom_components.haeo.core.schema.elements.policy import (
-    CONF_ENABLED as CONF_POLICY_ENABLED,
-    CONF_RULES,
-)
+from custom_components.haeo.core.schema.elements.policy import CONF_ENABLED as CONF_POLICY_ENABLED
+from custom_components.haeo.core.schema.elements.policy import CONF_RULES
 from custom_components.haeo.core.schema.elements.policy import ELEMENT_TYPE as POLICY_TYPE
 from custom_components.haeo.core.schema.elements.solar import (
     CONF_CURTAILMENT,

--- a/custom_components/haeo/translations/en.json
+++ b/custom_components/haeo/translations/en.json
@@ -547,6 +547,7 @@
       "network_auto_optimize": { "name": "Auto optimize" },
       "node_is_sink": { "name": "Is sink" },
       "node_is_source": { "name": "Is source" },
+      "policy_enabled": { "name": "{rule_name} enabled" },
       "solar_curtailment": { "name": "Curtailment" }
     }
   },


### PR DESCRIPTION
## Summary
- preserve existing `source`/`target` values when editing a policy rule if those fields are omitted from the submitted payload
- require `price` in policy rule flows and restrict choices to entity/constant (remove `none` behavior)
- update policy flow tests to cover preserved endpoints and required price validation

## Test plan
- [x] `uv run pytest custom_components/haeo/flows/tests/test_policy_flows.py`
- [ ] Validate policy rule edit behavior in Home Assistant UI (optional manual verification)

Made with [Cursor](https://cursor.com)