### PR TITLE
Fix policy endpoint choose restore ordering

### DIFF
--- a/custom_components/haeo/flows/elements/policy.py
+++ b/custom_components/haeo/flows/elements/policy.py
@@ -179,7 +179,12 @@ class PolicySubentryFlowHandler(ElementFlowMixin, ConfigSubentryFlow):
             preferred_choice=CHOICE_CONSTANT,
         )
 
-    def _build_endpoint_selector(self, participants: list[str]) -> _EndpointChooseSelector:
+    def _build_endpoint_selector(
+        self,
+        participants: list[str],
+        *,
+        preferred_choice: str = CHOICE_NONE,
+    ) -> _EndpointChooseSelector:
         """Build a ChooseSelector for endpoint with none (any) and elements (specific) choices."""
         options = [SelectOptionDict(value=p, label=p) for p in participants]
         elements_selector = SelectSelector(
@@ -190,28 +195,51 @@ class PolicySubentryFlowHandler(ElementFlowMixin, ConfigSubentryFlow):
             )
         )
         none_selector = ConstantSelector(ConstantSelectorConfig(value=""))
+        choice_map = {
+            CHOICE_NONE: ChooseSelectorChoiceConfig(
+                selector=none_selector.serialize()["selector"],
+            ),
+            CHOICE_ELEMENTS: ChooseSelectorChoiceConfig(
+                selector=elements_selector.serialize()["selector"],
+            ),
+        }
+        choice_order = [CHOICE_NONE, CHOICE_ELEMENTS]
+        if preferred_choice in choice_order:
+            choice_order.remove(preferred_choice)
+            choice_order.insert(0, preferred_choice)
+
         return _EndpointChooseSelector(
             ChooseSelectorConfig(
-                choices={
-                    CHOICE_NONE: ChooseSelectorChoiceConfig(
-                        selector=none_selector.serialize()["selector"],
-                    ),
-                    CHOICE_ELEMENTS: ChooseSelectorChoiceConfig(
-                        selector=elements_selector.serialize()["selector"],
-                    ),
-                },
+                choices={k: choice_map[k] for k in choice_order},
                 translation_key="policy_endpoint",
             )
         )
+
+    def _get_preferred_endpoint_choice(self, value: Any) -> str:
+        """Return endpoint choice key to place first in selector ordering."""
+        if isinstance(value, dict) and value.get("active_choice") == CHOICE_ELEMENTS:
+            return CHOICE_ELEMENTS
+        if isinstance(value, list) and value:
+            return CHOICE_ELEMENTS
+        return CHOICE_NONE
 
     def _build_rule_schema(
         self,
         source_options: list[str],
         target_options: list[str],
+        *,
+        source_preferred_choice: str = CHOICE_NONE,
+        target_preferred_choice: str = CHOICE_NONE,
     ) -> vol.Schema:
         """Build the schema for adding or editing a policy rule."""
-        source_selector = self._build_endpoint_selector(source_options)
-        target_selector = self._build_endpoint_selector(target_options)
+        source_selector = self._build_endpoint_selector(
+            source_options,
+            preferred_choice=source_preferred_choice,
+        )
+        target_selector = self._build_endpoint_selector(
+            target_options,
+            preferred_choice=target_preferred_choice,
+        )
         price_selector = self._build_price_selector()
 
         return vol.Schema(
@@ -389,7 +417,18 @@ class PolicySubentryFlowHandler(ElementFlowMixin, ConfigSubentryFlow):
                     data=self._build_entry_data(),
                 )
 
-        schema = self._build_rule_schema(source_options, target_options)
+        source_preferred_choice = CHOICE_NONE
+        target_preferred_choice = CHOICE_NONE
+        if user_input is not None:
+            source_preferred_choice = self._get_preferred_endpoint_choice(user_input.get(CONF_SOURCE))
+            target_preferred_choice = self._get_preferred_endpoint_choice(user_input.get(CONF_TARGET))
+
+        schema = self._build_rule_schema(
+            source_options,
+            target_options,
+            source_preferred_choice=source_preferred_choice,
+            target_preferred_choice=target_preferred_choice,
+        )
         if user_input is not None:
             schema = self.add_suggested_values_to_schema(schema, user_input)
 
@@ -470,13 +509,20 @@ class PolicySubentryFlowHandler(ElementFlowMixin, ConfigSubentryFlow):
                     data=self._build_entry_data(),
                 )
 
-        schema = self._build_rule_schema(source_options, target_options)
         if merged_input is not None:
             defaults = merged_input
         elif idx is not None and 0 <= idx < len(self._rules):
             defaults = self._rule_to_defaults(self._rules[idx])
         else:
             defaults = {}
+        source_preferred_choice = self._get_preferred_endpoint_choice(defaults.get(CONF_SOURCE))
+        target_preferred_choice = self._get_preferred_endpoint_choice(defaults.get(CONF_TARGET))
+        schema = self._build_rule_schema(
+            source_options,
+            target_options,
+            source_preferred_choice=source_preferred_choice,
+            target_preferred_choice=target_preferred_choice,
+        )
         schema = self.add_suggested_values_to_schema(schema, defaults)
 
         return self.async_show_form(

--- a/custom_components/haeo/flows/tests/test_policy_flows.py
+++ b/custom_components/haeo/flows/tests/test_policy_flows.py
@@ -117,6 +117,16 @@ def _get_suggested_value(result: Any, field_name: str) -> Any:
     return None
 
 
+def _get_selector(result: Any, field_name: str) -> Any:
+    """Extract selector instance for a field from a flow result's data_schema."""
+    data_schema = result.get("data_schema")
+    assert data_schema is not None
+    for key, selector in data_schema.schema.items():
+        if getattr(key, "schema", None) == field_name:
+            return selector
+    return None
+
+
 # --- User step (adding a policy rule) ---
 
 
@@ -804,6 +814,18 @@ def test_endpoint_selector_unknown_active_choice_delegates_to_super(
         sel({"active_choice": "unknown"})
 
 
+def test_endpoint_selector_elements_first_when_preferred(
+    hass: HomeAssistant,
+    hub_entry: MockConfigEntry,
+) -> None:
+    """Elements choice is placed first when preferred for restore behavior."""
+    flow = _create_flow(hass, hub_entry)
+    sel = flow._build_endpoint_selector(["Solar"], preferred_choice=CHOICE_ELEMENTS)
+    choices_keys = list(sel.config["choices"].keys())
+    assert choices_keys[0] == CHOICE_ELEMENTS
+    assert choices_keys[1] == CHOICE_NONE
+
+
 def test_get_participant_options_skips_invalid_element_type_values(
     hass: HomeAssistant,
     hub_entry: MockConfigEntry,
@@ -1083,6 +1105,12 @@ async def test_edit_rule_shows_previous_values_for_source_target(
     assert result.get("type") == FlowResultType.FORM
     assert _get_suggested_value(result, CONF_SOURCE) == {"active_choice": CHOICE_ELEMENTS, CHOICE_ELEMENTS: ["Solar"]}
     assert _get_suggested_value(result, CONF_TARGET) == {"active_choice": CHOICE_ELEMENTS, CHOICE_ELEMENTS: ["Grid"]}
+    source_selector = _get_selector(result, CONF_SOURCE)
+    target_selector = _get_selector(result, CONF_TARGET)
+    assert source_selector is not None
+    assert target_selector is not None
+    assert next(iter(source_selector.config["choices"].keys())) == CHOICE_ELEMENTS
+    assert next(iter(target_selector.config["choices"].keys())) == CHOICE_ELEMENTS
 
 
 async def test_edit_rule_shows_any_for_missing_source_target(

--- a/custom_components/haeo/flows/tests/test_policy_flows.py
+++ b/custom_components/haeo/flows/tests/test_policy_flows.py
@@ -1113,6 +1113,41 @@ async def test_edit_rule_shows_previous_values_for_source_target(
     assert next(iter(target_selector.config["choices"].keys())) == CHOICE_ELEMENTS
 
 
+async def test_edit_rule_ui_restore_contract_for_elements_endpoints(
+    hass: HomeAssistant,
+    hub_entry: MockConfigEntry,
+) -> None:
+    """UI restore works by aligning suggested value with first choose choice."""
+    existing_rules: list[PolicyRuleConfig] = [
+        {
+            "name": "Solar Export",
+            "source": ["Solar"],
+            "target": ["Grid"],
+            "price": as_constant_value(0.02),
+        },
+    ]
+    subentry = _make_policy_subentry(existing_rules)
+    hass.config_entries.async_add_subentry(hub_entry, subentry)
+
+    flow = _create_flow(hass, hub_entry)
+    flow.context = {"subentry_id": subentry.subentry_id}
+    flow._get_reconfigure_subentry = Mock(return_value=subentry)
+    flow._get_subentry = Mock(return_value=subentry)
+
+    await flow.async_step_reconfigure(user_input=None)
+    await flow.async_step_reconfigure(user_input={CONF_RULE: "0", CONF_ACTION: ACTION_EDIT})
+    result = await flow.async_step_edit_rule(user_input=None)
+
+    source_selector = _get_selector(result, CONF_SOURCE)
+    target_selector = _get_selector(result, CONF_TARGET)
+    assert source_selector is not None
+    assert target_selector is not None
+    assert next(iter(source_selector.config["choices"].keys())) == CHOICE_ELEMENTS
+    assert next(iter(target_selector.config["choices"].keys())) == CHOICE_ELEMENTS
+    assert _get_suggested_value(result, CONF_SOURCE) == {"active_choice": CHOICE_ELEMENTS, CHOICE_ELEMENTS: ["Solar"]}
+    assert _get_suggested_value(result, CONF_TARGET) == {"active_choice": CHOICE_ELEMENTS, CHOICE_ELEMENTS: ["Grid"]}
+
+
 async def test_edit_rule_shows_any_for_missing_source_target(
     hass: HomeAssistant,
     hub_entry: MockConfigEntry,
@@ -1139,6 +1174,13 @@ async def test_edit_rule_shows_any_for_missing_source_target(
 
     assert _get_suggested_value(result, CONF_SOURCE) == ""
     assert _get_suggested_value(result, CONF_TARGET) == ""
+
+    source_selector = _get_selector(result, CONF_SOURCE)
+    target_selector = _get_selector(result, CONF_TARGET)
+    assert source_selector is not None
+    assert target_selector is not None
+    assert next(iter(source_selector.config["choices"].keys())) == CHOICE_NONE
+    assert next(iter(target_selector.config["choices"].keys())) == CHOICE_NONE
 
 
 async def test_edit_rule_shows_previous_constant_price(


### PR DESCRIPTION
## Summary
- ensure policy endpoint `ChooseSelector` places the currently active choice first so restored values are correctly reflected in the UI
- derive preferred source/target choice ordering from current submitted/default values in both add and edit policy flows
- add policy flow regression tests that verify choice ordering and restored selector behavior for edit defaults

## Test plan
- [x] `uv run pytest custom_components/haeo/flows/tests/test_policy_flows.py`
- [x] `uv run ruff check custom_components/haeo/flows/elements/policy.py custom_components/haeo/flows/tests/test_policy_flows.py`
- [x] `uv run pyright custom_components/haeo/flows/elements/policy.py custom_components/haeo/flows/tests/test_policy_flows.py`

Made with [Cursor](https://cursor.com)