### PR TITLE
Publish versioned documentation site

### DIFF
--- a/.github/workflows/backfill-release-docs.yml
+++ b/.github/workflows/backfill-release-docs.yml
@@ -15,11 +15,6 @@ on:
         description: "Specific release tag to rebuild (e.g. v0.3.3). Leave empty to process every release missing docs-<tag>.zip."
         required: false
         default: ""
-  # TEMPORARY: run once on the PR branch so we can exercise this workflow in
-  # the real CI environment before it lands on main. Remove this trigger
-  # before merging.
-  push:
-    branches: [docs/versioned-site]
 
 permissions:
   contents: write

--- a/.github/workflows/backfill-release-docs.yml
+++ b/.github/workflows/backfill-release-docs.yml
@@ -53,7 +53,7 @@ jobs:
             echo "Will process single tag: ${INPUT_TAG}"
           else
             tags=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-              --jq '.[] | select([.assets[].name] | index("docs-" + .tag_name + ".zip") | not) | .tag_name' \
+              --jq '.[] | . as $r | select([.assets[].name] | index("docs-\($r.tag_name).zip") | not) | .tag_name' \
               | tr '\n' ' ')
             echo "tags=${tags}" >> "$GITHUB_OUTPUT"
             echo "Will process: ${tags:-<none>}"

--- a/.github/workflows/backfill-release-docs.yml
+++ b/.github/workflows/backfill-release-docs.yml
@@ -15,10 +15,6 @@ on:
         description: "Specific release tag to rebuild (e.g. v0.3.3). Leave empty to process every release missing docs-<tag>.zip."
         required: false
         default: ""
-  # TEMPORARY: run once on the PR branch so we can regenerate the single tag
-  # that has guide screenshots (v0.4.0rc1). Remove this trigger before merging.
-  push:
-    branches: [docs/versioned-site]
 
 permissions:
   contents: write

--- a/.github/workflows/backfill-release-docs.yml
+++ b/.github/workflows/backfill-release-docs.yml
@@ -14,6 +14,11 @@ on:
         description: "Specific release tag to rebuild (e.g. v0.3.3). Leave empty to process every release missing docs.zip."
         required: false
         default: ""
+  # TEMPORARY: run once on the PR branch so we can exercise this workflow in
+  # the real CI environment before it lands on main. Remove this trigger
+  # before merging.
+  push:
+    branches: [docs/versioned-site]
 
 permissions:
   contents: write

--- a/.github/workflows/backfill-release-docs.yml
+++ b/.github/workflows/backfill-release-docs.yml
@@ -68,11 +68,15 @@ jobs:
           failures=()
           for tag in $TAGS; do
             echo "::group::$tag"
-            workdir="/tmp/src-${tag//\//_}"
-            rm -rf "$workdir"
+            slug="${tag//\//_}"
+            workdir="/tmp/src-${slug}"
+            stagedir="/tmp/stage-${slug}"
+            rm -rf "$workdir" "$stagedir"
+            mkdir -p "$stagedir"
             if ! git worktree add --detach "$workdir" "$tag"; then
               echo "::error::Failed to create worktree for $tag"
               failures+=("$tag (worktree)")
+              rm -rf "$stagedir"
               echo "::endgroup::"
               continue
             fi
@@ -93,21 +97,29 @@ jobs:
                 uv run mkdocs build
               fi
 
-              (cd site && zip -r "/tmp/docs-${tag//\//_}.zip" .)
+              (cd site && zip -r "${stagedir}/docs.zip" .)
             ) || {
               echo "::error::Build failed for $tag"
               failures+=("$tag (build)")
               git worktree remove --force "$workdir" || true
+              rm -rf "$stagedir"
               echo "::endgroup::"
               continue
             }
 
-            if ! gh release upload "$tag" "/tmp/docs-${tag//\//_}.zip#docs.zip" --clobber; then
+            # Delete any legacy docs-<tag>.zip asset from a previous attempt.
+            legacy_asset="docs-${tag}.zip"
+            if gh release view "$tag" --json assets --jq ".assets[].name" \
+                | grep -Fxq "$legacy_asset"; then
+              gh release delete-asset "$tag" "$legacy_asset" --yes || true
+            fi
+
+            if ! gh release upload "$tag" "${stagedir}/docs.zip" --clobber; then
               echo "::error::Upload failed for $tag"
               failures+=("$tag (upload)")
             fi
 
-            rm -f "/tmp/docs-${tag//\//_}.zip"
+            rm -rf "$stagedir"
             git worktree remove --force "$workdir" || true
             echo "::endgroup::"
           done

--- a/.github/workflows/backfill-release-docs.yml
+++ b/.github/workflows/backfill-release-docs.yml
@@ -1,17 +1,18 @@
 name: Backfill Release Docs
 
-# One-time (or ad-hoc) workflow that builds docs.zip for existing GitHub
-# Releases and uploads it as a release asset. Use this to retro-fit docs onto
-# releases created before docs.yml started attaching them automatically.
+# Ad-hoc workflow that builds docs-<tag>.zip for existing GitHub Releases and
+# uploads it as a release asset. Use this to retro-fit docs onto releases
+# created before docs.yml started attaching them automatically.
 #
-# Without --tag, only releases that don't yet have a docs.zip asset are built.
-# Pass --tag to rebuild a specific one (will clobber the existing asset).
+# Without --tag, only releases that don't yet have a docs-<tag>.zip asset are
+# processed. Pass --tag to rebuild a specific one (will clobber the existing
+# asset).
 
 on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Specific release tag to rebuild (e.g. v0.3.3). Leave empty to process every release missing docs.zip."
+        description: "Specific release tag to rebuild (e.g. v0.3.3). Leave empty to process every release missing docs-<tag>.zip."
         required: false
         default: ""
   # TEMPORARY: run once on the PR branch so we can exercise this workflow in
@@ -52,13 +53,13 @@ jobs:
             echo "Will process single tag: ${INPUT_TAG}"
           else
             tags=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-              --jq '.[] | select([.assets[].name] | index("docs.zip") | not) | .tag_name' \
+              --jq '.[] | select([.assets[].name] | index("docs-" + .tag_name + ".zip") | not) | .tag_name' \
               | tr '\n' ' ')
             echo "tags=${tags}" >> "$GITHUB_OUTPUT"
             echo "Will process: ${tags:-<none>}"
           fi
 
-      - name: Build and upload docs.zip for each tag
+      - name: Build and upload docs for each tag
         if: steps.tags.outputs.tags != ''
         env:
           GH_TOKEN: ${{ github.token }}
@@ -81,6 +82,8 @@ jobs:
               continue
             fi
 
+            asset="docs-${tag}.zip"
+
             (
               set -euo pipefail
               cd "$workdir"
@@ -97,7 +100,7 @@ jobs:
                 uv run mkdocs build
               fi
 
-              (cd site && zip -r "${stagedir}/docs.zip" .)
+              (cd site && zip -r "${stagedir}/${asset}" .)
             ) || {
               echo "::error::Build failed for $tag"
               failures+=("$tag (build)")
@@ -107,14 +110,7 @@ jobs:
               continue
             }
 
-            # Delete any legacy docs-<tag>.zip asset from a previous attempt.
-            legacy_asset="docs-${tag}.zip"
-            if gh release view "$tag" --json assets --jq ".assets[].name" \
-                | grep -Fxq "$legacy_asset"; then
-              gh release delete-asset "$tag" "$legacy_asset" --yes || true
-            fi
-
-            if ! gh release upload "$tag" "${stagedir}/docs.zip" --clobber; then
+            if ! gh release upload "$tag" "${stagedir}/${asset}" --clobber; then
               echo "::error::Upload failed for $tag"
               failures+=("$tag (upload)")
             fi

--- a/.github/workflows/backfill-release-docs.yml
+++ b/.github/workflows/backfill-release-docs.yml
@@ -1,0 +1,114 @@
+name: Backfill Release Docs
+
+# One-time (or ad-hoc) workflow that builds docs.zip for existing GitHub
+# Releases and uploads it as a release asset. Use this to retro-fit docs onto
+# releases created before docs.yml started attaching them automatically.
+#
+# Without --tag, only releases that don't yet have a docs.zip asset are built.
+# Pass --tag to rebuild a specific one (will clobber the existing asset).
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Specific release tag to rebuild (e.g. v0.3.3). Leave empty to process every release missing docs.zip."
+        required: false
+        default: ""
+
+permissions:
+  contents: write
+
+jobs:
+  backfill:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main (for git worktree host repo)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@61cb8a9741eeb8a550a1b8544337180c0fc8476b # v7.2.0
+        with:
+          version: "latest"
+
+      - name: Install optipng
+        run: sudo apt-get install -y optipng
+
+      - name: Determine tags to process
+        id: tags
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          if [[ -n "${INPUT_TAG}" ]]; then
+            echo "tags=${INPUT_TAG}" >> "$GITHUB_OUTPUT"
+            echo "Will process single tag: ${INPUT_TAG}"
+          else
+            tags=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+              --jq '.[] | select([.assets[].name] | index("docs.zip") | not) | .tag_name' \
+              | tr '\n' ' ')
+            echo "tags=${tags}" >> "$GITHUB_OUTPUT"
+            echo "Will process: ${tags:-<none>}"
+          fi
+
+      - name: Build and upload docs.zip for each tag
+        if: steps.tags.outputs.tags != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAGS: ${{ steps.tags.outputs.tags }}
+        run: |
+          set -uo pipefail
+          failures=()
+          for tag in $TAGS; do
+            echo "::group::$tag"
+            workdir="/tmp/src-${tag//\//_}"
+            rm -rf "$workdir"
+            if ! git worktree add --detach "$workdir" "$tag"; then
+              echo "::error::Failed to create worktree for $tag"
+              failures+=("$tag (worktree)")
+              echo "::endgroup::"
+              continue
+            fi
+
+            (
+              set -euo pipefail
+              cd "$workdir"
+
+              if [[ -f uv.lock ]]; then
+                uv sync --locked --all-extras --dev || uv sync --all-extras --dev
+              else
+                uv sync --all-extras --dev
+              fi
+
+              if grep -q '"zensical' pyproject.toml || [[ -f zensical.toml ]]; then
+                uv run zensical build
+              else
+                uv run mkdocs build
+              fi
+
+              (cd site && zip -r "/tmp/docs-${tag//\//_}.zip" .)
+            ) || {
+              echo "::error::Build failed for $tag"
+              failures+=("$tag (build)")
+              git worktree remove --force "$workdir" || true
+              echo "::endgroup::"
+              continue
+            }
+
+            if ! gh release upload "$tag" "/tmp/docs-${tag//\//_}.zip#docs.zip" --clobber; then
+              echo "::error::Upload failed for $tag"
+              failures+=("$tag (upload)")
+            fi
+
+            rm -f "/tmp/docs-${tag//\//_}.zip"
+            git worktree remove --force "$workdir" || true
+            echo "::endgroup::"
+          done
+
+          if (( ${#failures[@]} > 0 )); then
+            echo "::warning::Finished with failures: ${failures[*]}"
+            exit 1
+          fi
+          echo "All tags processed successfully."

--- a/.github/workflows/backfill-release-docs.yml
+++ b/.github/workflows/backfill-release-docs.yml
@@ -15,6 +15,10 @@ on:
         description: "Specific release tag to rebuild (e.g. v0.3.3). Leave empty to process every release missing docs-<tag>.zip."
         required: false
         default: ""
+  # TEMPORARY: run once on the PR branch so we can regenerate the single tag
+  # that has guide screenshots (v0.4.0rc1). Remove this trigger before merging.
+  push:
+    branches: [docs/versioned-site]
 
 permissions:
   contents: write
@@ -87,6 +91,16 @@ jobs:
                 uv sync --locked --all-extras --dev || uv sync --all-extras --dev
               else
                 uv sync --all-extras --dev
+              fi
+
+              # Generate guide screenshots if this tag declares a `guide` pytest marker.
+              if grep -q '"guide:' pyproject.toml; then
+                echo "Tag $tag has guide tests; installing Playwright and regenerating screenshots."
+                uv run playwright install --with-deps firefox
+                uv run pytest -m guide -v --timeout=300
+                find docs -name '*.png' -exec optipng -o5 -quiet {} +
+              else
+                echo "Tag $tag has no guide marker; skipping screenshot generation."
               fi
 
               if grep -q '"zensical' pyproject.toml || [[ -f zensical.toml ]]; then

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,8 @@
 name: Deploy Documentation
 
 on:
+  push:
+    branches: [main]
   release:
     types: [published]
   workflow_dispatch:
@@ -20,19 +22,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Get latest release tag
-        id: latest_release
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          LATEST_TAG=$(gh api repos/${{ github.repository }}/releases/latest --jq '.tag_name')
-          echo "tag=$LATEST_TAG" >> $GITHUB_OUTPUT
-          echo "Building documentation for release: $LATEST_TAG"
-
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ steps.latest_release.outputs.tag }}
           fetch-depth: 0
 
       - name: Install uv
@@ -54,13 +46,19 @@ jobs:
           sudo apt-get install -y optipng
           find docs -name '*.png' -exec optipng -o5 -quiet {} +
 
-      - name: Build documentation
+      - name: Build main documentation
         run: uv run zensical build
+
+      - name: Assemble versioned site
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: uv run python tools/assemble_docs.py --main-site ./site --output ./public
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
         with:
-          path: ./site
+          path: ./public
 
   deploy:
     environment:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,3 +74,52 @@ jobs:
         with:
           files: |
             haeo.zip
+
+  build-docs:
+    name: Build and attach docs
+    needs: validate-release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.release.tag_name }}
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@61cb8a9741eeb8a550a1b8544337180c0fc8476b # v7.2.0
+        with:
+          version: "latest"
+
+      - name: Install dependencies
+        run: uv sync --locked --all-extras --dev
+
+      - name: Install Playwright browsers
+        run: uv run playwright install --with-deps firefox
+
+      - name: Generate guide screenshots
+        run: uv run pytest -m guide -v --timeout=300
+
+      - name: Optimize screenshots
+        run: |
+          sudo apt-get install -y optipng
+          find docs -name '*.png' -exec optipng -o5 -quiet {} +
+
+      - name: Build documentation
+        run: |
+          if [ -f zensical.toml ] || grep -q '"zensical' pyproject.toml; then
+            uv run zensical build
+          else
+            uv run mkdocs build
+          fi
+
+      - name: Package documentation
+        run: |
+          cd site
+          zip -r ../docs.zip .
+
+      - name: Upload docs as release asset
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
+        with:
+          files: |
+            docs.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,12 +114,14 @@ jobs:
           fi
 
       - name: Package documentation
+        env:
+          TAG: ${{ github.event.release.tag_name }}
         run: |
           cd site
-          zip -r ../docs.zip .
+          zip -r "../docs-${TAG}.zip" .
 
       - name: Upload docs as release asset
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
         with:
           files: |
-            docs.zip
+            docs-${{ github.event.release.tag_name }}.zip

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: HAEO Documentation
 site_description: Home Assistant Energy Optimizer - Real-time energy management using linear programming
 site_author: Trent Houliston
-site_url: https://hass-energy.github.io/haeo/
+site_url: https://haeo.io/
 repo_url: https://github.com/hass-energy/haeo
 repo_name: hass-energy/haeo
 edit_uri: edit/main/docs/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dev = [
     "ruff>=0.14.10",
     "setuptools>=80.9.0",
     "syrupy>=5.0.0",
-    "zensical>=0.0.24",
+    "zensical>=0.0.30",
     "import-linter>=2.10",
     "pytest-benchmark>=5.2.3",
 ]

--- a/tests/test_assemble_docs.py
+++ b/tests/test_assemble_docs.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from tools import assemble_docs
-from tools.assemble_docs import Release, build_version_entries, parse_tag, write_redirect
+from tools.assemble_docs import Release, build_version_entries, docs_asset_name, parse_tag, write_redirect
 
 
 def test_parse_tag_stable() -> None:
@@ -88,7 +88,12 @@ def test_write_redirect(tmp_path: Path) -> None:
     assert '<link rel="canonical" href="./latest/">' in content
 
 
+def test_docs_asset_name() -> None:
+    """Release docs assets are namespaced by tag so each release gets its own filename."""
+    assert docs_asset_name("v0.3.3") == "docs-v0.3.3.zip"
+    assert docs_asset_name("v0.4.0rc1") == "docs-v0.4.0rc1.zip"
+
+
 def test_module_constants() -> None:
-    """Sanity-check a couple of module-level constants we rely on in workflows."""
-    assert assemble_docs.DOCS_ASSET == "docs.zip"
+    """Sanity-check module-level constants relied on by workflows."""
     assert assemble_docs.DEFAULT_CNAME == "haeo.io"

--- a/tests/test_assemble_docs.py
+++ b/tests/test_assemble_docs.py
@@ -1,0 +1,94 @@
+"""Tests for the documentation assembly helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tools import assemble_docs
+from tools.assemble_docs import Release, build_version_entries, parse_tag, write_redirect
+
+
+def test_parse_tag_stable() -> None:
+    """A stable ``vX.Y.Z`` tag parses with the stable sentinel rc rank."""
+    result = parse_tag("v0.3.3")
+    assert result is not None
+    assert result.tag == "v0.3.3"
+    assert result.version == "0.3.3"
+    assert result.is_rc is False
+    assert result.sort_key[:3] == (0, 3, 3)
+
+
+def test_parse_tag_rc() -> None:
+    """A release-candidate tag is flagged and sorts before the matching stable."""
+    rc = parse_tag("v0.4.0rc1")
+    stable = parse_tag("v0.4.0")
+    assert rc is not None
+    assert stable is not None
+    assert rc.is_rc is True
+    assert rc.version == "0.4.0rc1"
+    assert rc.sort_key < stable.sort_key
+
+
+def test_parse_tag_rejects_non_standard() -> None:
+    """Tags that don't match the release regex (e.g. alphas) are ignored."""
+    assert parse_tag("v0.1.0-alpha") is None
+    assert parse_tag("main") is None
+    assert parse_tag("") is None
+
+
+def test_parse_tag_sort_order() -> None:
+    """Sorting newest-first groups RCs before their stable and higher X.Y.Z first."""
+    tags = ["v0.1.0", "v0.2.0", "v0.3.0rc1", "v0.3.0", "v0.3.3", "v0.4.0rc1"]
+    parsed = [p for p in (parse_tag(t) for t in tags) if p is not None]
+    parsed.sort(key=lambda r: r.sort_key, reverse=True)
+    assert [r.tag for r in parsed] == [
+        "v0.4.0rc1",
+        "v0.3.3",
+        "v0.3.0",
+        "v0.3.0rc1",
+        "v0.2.0",
+        "v0.1.0",
+    ]
+
+
+def _release(tag: str, *, is_rc: bool) -> Release:
+    """Minimal Release factory for tests."""
+    return Release(tag=tag, version=tag[1:], sort_key=(0, 0, 0, 0), is_rc=is_rc)
+
+
+def test_build_version_entries_sets_latest_and_dev_aliases() -> None:
+    """versions.json places main first with ``dev`` alias; newest non-rc gets ``latest``."""
+    rc = _release("v0.4.0rc1", is_rc=True)
+    stable = _release("v0.3.3", is_rc=False)
+    older = _release("v0.2.0", is_rc=False)
+    entries = build_version_entries([rc, stable, older], stable, "main", "dev", "latest")
+    assert entries[0] == {"version": "main", "title": "main", "aliases": ["dev"]}
+    versions = [entry["version"] for entry in entries]
+    assert versions == ["main", "0.4.0rc1", "0.3.3", "0.2.0"]
+    aliases_by_version = {entry["version"]: entry["aliases"] for entry in entries}
+    assert aliases_by_version["0.3.3"] == ["latest"]
+    assert aliases_by_version["0.4.0rc1"] == []
+    assert aliases_by_version["0.2.0"] == []
+
+
+def test_build_version_entries_no_stable() -> None:
+    """When no non-rc release exists, no version gets the ``latest`` alias."""
+    rc = _release("v0.4.0rc1", is_rc=True)
+    entries = build_version_entries([rc], None, "main", "dev", "latest")
+    for entry in entries:
+        assert "latest" not in entry["aliases"]
+
+
+def test_write_redirect(tmp_path: Path) -> None:
+    """The redirect file meta-refreshes to the given target."""
+    path = tmp_path / "index.html"
+    write_redirect(path, "latest")
+    content = path.read_text(encoding="utf-8")
+    assert '<meta http-equiv="refresh" content="0; url=./latest/">' in content
+    assert '<link rel="canonical" href="./latest/">' in content
+
+
+def test_module_constants() -> None:
+    """Sanity-check a couple of module-level constants we rely on in workflows."""
+    assert assemble_docs.DOCS_ASSET == "docs.zip"
+    assert assemble_docs.DEFAULT_CNAME == "haeo.io"

--- a/tests/test_assemble_docs.py
+++ b/tests/test_assemble_docs.py
@@ -3,9 +3,19 @@
 from __future__ import annotations
 
 from pathlib import Path
+import zipfile
+
+import pytest
 
 from tools import assemble_docs
-from tools.assemble_docs import Release, build_version_entries, docs_asset_name, parse_tag, write_redirect
+from tools.assemble_docs import (
+    Release,
+    _safe_extract,
+    build_version_entries,
+    docs_asset_name,
+    parse_tag,
+    write_redirect,
+)
 
 
 def test_parse_tag_stable() -> None:
@@ -37,7 +47,7 @@ def test_parse_tag_rejects_non_standard() -> None:
 
 
 def test_parse_tag_sort_order() -> None:
-    """Sorting newest-first groups RCs before their stable and higher X.Y.Z first."""
+    """Sorting newest-first puts higher X.Y.Z first and stable releases before matching RCs."""
     tags = ["v0.1.0", "v0.2.0", "v0.3.0rc1", "v0.3.0", "v0.3.3", "v0.4.0rc1"]
     parsed = [p for p in (parse_tag(t) for t in tags) if p is not None]
     parsed.sort(key=lambda r: r.sort_key, reverse=True)
@@ -97,3 +107,30 @@ def test_docs_asset_name() -> None:
 def test_module_constants() -> None:
     """Sanity-check module-level constants relied on by workflows."""
     assert assemble_docs.DEFAULT_CNAME == "haeo.io"
+
+
+def test_safe_extract_accepts_clean_zip(tmp_path: Path) -> None:
+    """A well-formed archive extracts normally."""
+    archive_path = tmp_path / "clean.zip"
+    with zipfile.ZipFile(archive_path, "w") as zf:
+        zf.writestr("index.html", "<!DOCTYPE html>")
+        zf.writestr("assets/app.js", "console.log('ok');")
+    dest = tmp_path / "out"
+    dest.mkdir()
+    with zipfile.ZipFile(archive_path) as zf:
+        _safe_extract(zf, dest)
+    assert (dest / "index.html").read_text() == "<!DOCTYPE html>"
+    assert (dest / "assets" / "app.js").exists()
+
+
+@pytest.mark.parametrize("unsafe_name", ["../escape.txt", "/etc/passwd", "a/../../escape.txt"])
+def test_safe_extract_rejects_traversal(tmp_path: Path, unsafe_name: str) -> None:
+    """Archives with path-traversal entries are refused before any files are written."""
+    archive_path = tmp_path / "evil.zip"
+    with zipfile.ZipFile(archive_path, "w") as zf:
+        zf.writestr(unsafe_name, "pwned")
+    dest = tmp_path / "out"
+    dest.mkdir()
+    with zipfile.ZipFile(archive_path) as zf, pytest.raises(ValueError, match="zip entry"):
+        _safe_extract(zf, dest)
+    assert list(dest.iterdir()) == []

--- a/tools/assemble_docs.py
+++ b/tools/assemble_docs.py
@@ -37,9 +37,13 @@ import tempfile
 from typing import Any
 import zipfile
 
-DOCS_ASSET = "docs.zip"
 DEFAULT_CNAME = "haeo.io"
 TAG_RE = re.compile(r"^v(\d+)\.(\d+)\.(\d+)(?:rc(\d+))?$")
+
+
+def docs_asset_name(tag: str) -> str:
+    """Return the expected docs asset filename for a release tag (e.g. ``docs-v0.3.3.zip``)."""
+    return f"docs-{tag}.zip"
 
 
 @dataclass(frozen=True)
@@ -69,7 +73,7 @@ def parse_tag(tag: str) -> Release | None:
 
 
 def fetch_releases(repo: str) -> list[Release]:
-    """Return releases (newest first) that have a ``docs.zip`` asset attached."""
+    """Return releases (newest first) that have a ``docs-<tag>.zip`` asset attached."""
     result = subprocess.run(  # noqa: S603
         ["gh", "api", f"repos/{repo}/releases", "--paginate"],  # noqa: S607
         capture_output=True,
@@ -85,8 +89,9 @@ def fetch_releases(repo: str) -> list[Release]:
             continue
         assets = entry.get("assets") or []
         names = {str(asset.get("name") or "") for asset in assets}
-        if DOCS_ASSET not in names:
-            print(f"  skipping {tag}: no {DOCS_ASSET} asset")
+        expected = docs_asset_name(tag)
+        if expected not in names:
+            print(f"  skipping {tag}: no {expected} asset")
             continue
         releases.append(parsed)
     releases.sort(key=lambda r: r.sort_key, reverse=True)
@@ -94,7 +99,8 @@ def fetch_releases(repo: str) -> list[Release]:
 
 
 def download_docs(repo: str, tag: str, dest: Path) -> None:
-    """Download ``docs.zip`` for a release and extract it into ``dest``."""
+    """Download the release's ``docs-<tag>.zip`` asset and extract it into ``dest``."""
+    asset = docs_asset_name(tag)
     with tempfile.TemporaryDirectory() as td:
         subprocess.run(  # noqa: S603
             [  # noqa: S607
@@ -105,13 +111,13 @@ def download_docs(repo: str, tag: str, dest: Path) -> None:
                 "--repo",
                 repo,
                 "--pattern",
-                DOCS_ASSET,
+                asset,
                 "--dir",
                 td,
             ],
             check=True,
         )
-        zip_path = Path(td) / DOCS_ASSET
+        zip_path = Path(td) / asset
         if dest.exists():
             shutil.rmtree(dest)
         dest.mkdir(parents=True)
@@ -208,7 +214,7 @@ def main(argv: list[str] | None = None) -> int:
 
     print(f"Listing releases for {repo}")
     releases = fetch_releases(repo)
-    print(f"Found {len(releases)} release(s) with {DOCS_ASSET}")
+    print(f"Found {len(releases)} release(s) with a docs-<tag>.zip asset")
     for release in releases:
         rel_dir = output / release.version
         print(f"Downloading {release.tag} -> {rel_dir}")

--- a/tools/assemble_docs.py
+++ b/tools/assemble_docs.py
@@ -66,8 +66,9 @@ def parse_tag(tag: str) -> Release | None:
     patch = int(match.group(3))
     rc_raw = match.group(4)
     is_rc = rc_raw is not None
-    # Stable releases sort after their release candidates (same X.Y.Z); use a
-    # large sentinel for stable so the tuple comparison places it last.
+    # Within the same X.Y.Z, stable releases should sort *newer* than their RCs.
+    # `releases.sort(..., reverse=True)` puts larger tuples first, so use a large
+    # sentinel for the stable rc_rank to float it above any rcN.
     rc_rank = int(rc_raw) if rc_raw is not None else sys.maxsize
     return Release(tag=tag, version=tag[1:], sort_key=(major, minor, patch, rc_rank), is_rc=is_rc)
 
@@ -98,6 +99,27 @@ def fetch_releases(repo: str) -> list[Release]:
     return releases
 
 
+def _safe_extract(archive: zipfile.ZipFile, dest: Path) -> None:
+    """Extract ``archive`` into ``dest`` while rejecting Zip Slip path traversal.
+
+    Even though our zips come from trusted release assets, validating each member
+    keeps us safe if an asset is ever replaced or tampered with.
+    """
+    dest_root = dest.resolve()
+    for member in archive.infolist():
+        name = member.filename
+        if name.startswith("/") or "\\" in name or ".." in Path(name).parts:
+            msg = f"refusing to extract unsafe zip entry: {name!r}"
+            raise ValueError(msg)
+        target = (dest_root / name).resolve()
+        try:
+            target.relative_to(dest_root)
+        except ValueError as exc:
+            msg = f"zip entry escapes destination: {name!r}"
+            raise ValueError(msg) from exc
+    archive.extractall(dest)
+
+
 def download_docs(repo: str, tag: str, dest: Path) -> None:
     """Download the release's ``docs-<tag>.zip`` asset and extract it into ``dest``."""
     asset = docs_asset_name(tag)
@@ -122,7 +144,7 @@ def download_docs(repo: str, tag: str, dest: Path) -> None:
             shutil.rmtree(dest)
         dest.mkdir(parents=True)
         with zipfile.ZipFile(zip_path) as archive:
-            archive.extractall(dest)
+            _safe_extract(archive, dest)
 
 
 def copy_tree(src: Path, dst: Path) -> None:

--- a/tools/assemble_docs.py
+++ b/tools/assemble_docs.py
@@ -1,0 +1,244 @@
+"""Assemble a versioned documentation site.
+
+Combines a freshly built ``main`` site with ``docs.zip`` assets downloaded from
+every GitHub Release that has one attached, producing a single tree ready to
+upload as a GitHub Pages artifact.
+
+Output layout::
+
+    output/
+        main/           # freshly built main docs
+        0.4.0rc1/       # unzipped release asset
+        0.3.3/          # unzipped release asset
+        ...
+        dev/            # full copy of main/ (alias)
+        latest/         # full copy of newest non-rc release (alias)
+        versions.json   # mike-format version manifest read by the theme
+        index.html      # root redirect to ./latest/
+        CNAME           # custom domain for GitHub Pages
+
+The script shells out to ``gh`` to list releases and download assets; it
+therefore requires ``gh`` to be on ``PATH`` and ``GH_TOKEN`` / ``GITHUB_TOKEN``
+to be set in the environment.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from typing import Any
+import zipfile
+
+DOCS_ASSET = "docs.zip"
+DEFAULT_CNAME = "haeo.io"
+TAG_RE = re.compile(r"^v(\d+)\.(\d+)\.(\d+)(?:rc(\d+))?$")
+
+
+@dataclass(frozen=True)
+class Release:
+    """Parsed release reference."""
+
+    tag: str
+    version: str
+    sort_key: tuple[int, int, int, int]
+    is_rc: bool
+
+
+def parse_tag(tag: str) -> Release | None:
+    """Parse a ``vX.Y.Z[rcN]`` tag into a Release, or return None if unsupported."""
+    match = TAG_RE.match(tag)
+    if match is None:
+        return None
+    major = int(match.group(1))
+    minor = int(match.group(2))
+    patch = int(match.group(3))
+    rc_raw = match.group(4)
+    is_rc = rc_raw is not None
+    # Stable releases sort after their release candidates (same X.Y.Z); use a
+    # large sentinel for stable so the tuple comparison places it last.
+    rc_rank = int(rc_raw) if rc_raw is not None else sys.maxsize
+    return Release(tag=tag, version=tag[1:], sort_key=(major, minor, patch, rc_rank), is_rc=is_rc)
+
+
+def fetch_releases(repo: str) -> list[Release]:
+    """Return releases (newest first) that have a ``docs.zip`` asset attached."""
+    result = subprocess.run(  # noqa: S603
+        ["gh", "api", f"repos/{repo}/releases", "--paginate"],  # noqa: S607
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    payload: list[dict[str, Any]] = json.loads(result.stdout)
+    releases: list[Release] = []
+    for entry in payload:
+        tag = str(entry.get("tag_name") or "")
+        parsed = parse_tag(tag)
+        if parsed is None:
+            continue
+        assets = entry.get("assets") or []
+        names = {str(asset.get("name") or "") for asset in assets}
+        if DOCS_ASSET not in names:
+            print(f"  skipping {tag}: no {DOCS_ASSET} asset")
+            continue
+        releases.append(parsed)
+    releases.sort(key=lambda r: r.sort_key, reverse=True)
+    return releases
+
+
+def download_docs(repo: str, tag: str, dest: Path) -> None:
+    """Download ``docs.zip`` for a release and extract it into ``dest``."""
+    with tempfile.TemporaryDirectory() as td:
+        subprocess.run(  # noqa: S603
+            [  # noqa: S607
+                "gh",
+                "release",
+                "download",
+                tag,
+                "--repo",
+                repo,
+                "--pattern",
+                DOCS_ASSET,
+                "--dir",
+                td,
+            ],
+            check=True,
+        )
+        zip_path = Path(td) / DOCS_ASSET
+        if dest.exists():
+            shutil.rmtree(dest)
+        dest.mkdir(parents=True)
+        with zipfile.ZipFile(zip_path) as archive:
+            archive.extractall(dest)
+
+
+def copy_tree(src: Path, dst: Path) -> None:
+    """Replace ``dst`` with a recursive copy of ``src``."""
+    if dst.exists():
+        shutil.rmtree(dst)
+    shutil.copytree(src, dst)
+
+
+def write_redirect(path: Path, target: str) -> None:
+    """Write an HTML meta-refresh redirect at ``path`` pointing to ``./{target}/``."""
+    html = (
+        "<!DOCTYPE html>\n"
+        '<html lang="en">\n'
+        "<head>\n"
+        '  <meta charset="utf-8">\n'
+        f"  <title>Redirecting to {target}/</title>\n"
+        f'  <meta http-equiv="refresh" content="0; url=./{target}/">\n'
+        f'  <link rel="canonical" href="./{target}/">\n'
+        "</head>\n"
+        "<body>\n"
+        f'  <p>Redirecting to <a href="./{target}/">{target}/</a>.</p>\n'
+        "</body>\n"
+        "</html>\n"
+    )
+    path.write_text(html, encoding="utf-8")
+
+
+def build_version_entries(
+    releases: list[Release],
+    latest: Release | None,
+    main_version: str,
+    dev_alias: str,
+    latest_alias: str,
+) -> list[dict[str, Any]]:
+    """Build the mike-format ``versions.json`` payload (newest first, ``main`` on top)."""
+    entries: list[dict[str, Any]] = [
+        {"version": main_version, "title": main_version, "aliases": [dev_alias]},
+    ]
+    for release in releases:
+        aliases: list[str] = []
+        if latest is not None and release.tag == latest.tag:
+            aliases.append(latest_alias)
+        entries.append({"version": release.version, "title": release.version, "aliases": aliases})
+    return entries
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--main-site", type=Path, required=True, help="Freshly built main site directory.")
+    parser.add_argument("--output", type=Path, required=True, help="Destination tree to write.")
+    parser.add_argument(
+        "--repo",
+        default=os.environ.get("GITHUB_REPOSITORY"),
+        help="owner/repo (defaults to $GITHUB_REPOSITORY).",
+    )
+    parser.add_argument("--cname", default=DEFAULT_CNAME, help="Custom domain to write as CNAME.")
+    parser.add_argument("--main-version", default="main", help="Subdirectory name for the main build.")
+    parser.add_argument("--dev-alias", default="dev", help="Alias for the main build.")
+    parser.add_argument("--latest-alias", default="latest", help="Alias for the newest non-rc release.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point — see module docstring for behaviour."""
+    args = _parse_args(argv)
+    repo: str | None = args.repo
+    if not repo:
+        print("error: --repo or GITHUB_REPOSITORY must be set", file=sys.stderr)
+        return 2
+
+    main_site: Path = args.main_site
+    output: Path = args.output
+    if not main_site.is_dir():
+        print(f"error: main site directory not found: {main_site}", file=sys.stderr)
+        return 2
+
+    if output.exists():
+        shutil.rmtree(output)
+    output.mkdir(parents=True)
+
+    main_version: str = args.main_version
+    dev_alias: str = args.dev_alias
+    latest_alias: str = args.latest_alias
+
+    main_dir = output / main_version
+    print(f"Copying main site -> {main_dir}")
+    shutil.copytree(main_site, main_dir)
+
+    print(f"Listing releases for {repo}")
+    releases = fetch_releases(repo)
+    print(f"Found {len(releases)} release(s) with {DOCS_ASSET}")
+    for release in releases:
+        rel_dir = output / release.version
+        print(f"Downloading {release.tag} -> {rel_dir}")
+        download_docs(repo, release.tag, rel_dir)
+
+    latest: Release | None = next((r for r in releases if not r.is_rc), None)
+    if latest is not None:
+        print(f"Aliasing {latest_alias}/ -> {latest.version}/")
+        copy_tree(output / latest.version, output / latest_alias)
+    else:
+        print("No non-rc release available; skipping latest alias")
+
+    print(f"Aliasing {dev_alias}/ -> {main_version}/")
+    copy_tree(main_dir, output / dev_alias)
+
+    entries = build_version_entries(releases, latest, main_version, dev_alias, latest_alias)
+    versions_path = output / "versions.json"
+    versions_path.write_text(json.dumps(entries, indent=2) + "\n", encoding="utf-8")
+    print(f"Wrote {versions_path} ({len(entries)} entries)")
+
+    redirect_target = latest_alias if latest is not None else main_version
+    write_redirect(output / "index.html", redirect_target)
+    print(f"Wrote root redirect -> ./{redirect_target}/")
+
+    cname: str = args.cname
+    (output / "CNAME").write_text(cname + "\n", encoding="utf-8")
+    print(f"Wrote CNAME={cname}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.13.2, <3.14"
 
 [[package]]
@@ -1124,7 +1124,7 @@ dev = [
     { name = "setuptools", specifier = ">=80.9.0" },
     { name = "syrupy", specifier = ">=5.0.0" },
     { name = "tabulate", specifier = ">=0.9.0" },
-    { name = "zensical", specifier = ">=0.0.24" },
+    { name = "zensical", specifier = ">=0.0.30" },
 ]
 
 [[package]]
@@ -2262,11 +2262,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]
@@ -2294,15 +2294,15 @@ wheels = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.19.1"
+version = "10.21.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/72/2d/9f30cee56d4d6d222430d401e85b0a6a1ae229819362f5786943d1a8c03b/pymdown_extensions-10.19.1.tar.gz", hash = "sha256:4969c691009a389fb1f9712dd8e7bd70dcc418d15a0faf70acb5117d022f7de8", size = 847839, upload-time = "2025-12-14T17:25:24.42Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/08/f1c908c581fd11913da4711ea7ba32c0eee40b0190000996bb863b0c9349/pymdown_extensions-10.21.2.tar.gz", hash = "sha256:c3f55a5b8a1d0edf6699e35dcbea71d978d34ff3fa79f3d807b8a5b3fa90fbdc", size = 853922, upload-time = "2026-03-29T15:01:55.233Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/35/b763e8fbcd51968329b9adc52d188fc97859f85f2ee15fe9f379987d99c5/pymdown_extensions-10.19.1-py3-none-any.whl", hash = "sha256:e8698a66055b1dc0dca2a7f2c9d0ea6f5faa7834a9c432e3535ab96c0c4e509b", size = 266693, upload-time = "2025-12-14T17:25:22.999Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/27/a2fc51a4a122dfd1015e921ae9d22fee3d20b0b8080d9a704578bf9deece/pymdown_extensions-10.21.2-py3-none-any.whl", hash = "sha256:5c0fd2a2bea14eb39af8ff284f1066d898ab2187d81b889b75d46d4348c01638", size = 268901, upload-time = "2026-03-29T15:01:53.244Z" },
 ]
 
 [[package]]
@@ -3488,7 +3488,7 @@ wheels = [
 
 [[package]]
 name = "zensical"
-version = "0.0.24"
+version = "0.0.33"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -3498,20 +3498,20 @@ dependencies = [
     { name = "pymdown-extensions" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3b/96/9c6cbdd7b351d1023cdbbcf7872d4cb118b0334cfe5821b99e0dd18e3f00/zensical-0.0.24.tar.gz", hash = "sha256:b5d99e225329bf4f98c8022bdf0a0ee9588c2fada7b4df1b7b896fcc62b37ec3", size = 3840688, upload-time = "2026-02-26T09:43:44.557Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/59/c2/dea4b86dc1ca2a7b55414017f12cfb12b5cfdf3a1ed7c77a04c271eb523b/zensical-0.0.33.tar.gz", hash = "sha256:05209cb4f80185c533e0d37c25d084ddc2050e3d5a4dd1b1812961c2ee0c3380", size = 3892278, upload-time = "2026-04-14T11:08:19.895Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8e/aa/b8201af30e376a67566f044a1c56210edac5ae923fd986a836d2cf593c9c/zensical-0.0.24-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:d390c5453a5541ca35d4f9e1796df942b6612c546e3153dd928236d3b758409a", size = 12263407, upload-time = "2026-02-26T09:43:14.716Z" },
-    { url = "https://files.pythonhosted.org/packages/78/8e/3d910214471ade604fd39b080db3696864acc23678b5b4b8475c7dbfd2ce/zensical-0.0.24-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:81ac072869cf4d280853765b2bfb688653da0dfb9408f3ab15aca96455ab8223", size = 12142610, upload-time = "2026-02-26T09:43:17.546Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/d7/eb0983640aa0419ddf670298cfbcf8b75629b6484925429b857851e00784/zensical-0.0.24-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b5eb1dfa84cae8e960bfa2c6851d2bc8e9710c4c4c683bd3aaf23185f646ae46", size = 12508380, upload-time = "2026-02-26T09:43:20.114Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/04/4405b9e6f937a75db19f0d875798a7eb70817d6a3bec2a2d289a2d5e8aea/zensical-0.0.24-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:57d7c9e589da99c1879a1c703e67c85eaa6be4661cdc6ce6534f7bb3575983f4", size = 12440807, upload-time = "2026-02-26T09:43:22.679Z" },
-    { url = "https://files.pythonhosted.org/packages/12/dc/a7ca2a4224b3072a2c2998b6611ad7fd4f8f131ceae7aa23238d97d26e22/zensical-0.0.24-cp310-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:42fcc121c3095734b078a95a0dae4d4924fb8fbf16bf730456146ad6cab48ad0", size = 12782727, upload-time = "2026-02-26T09:43:25.347Z" },
-    { url = "https://files.pythonhosted.org/packages/42/37/22f1727da356ed3fcbd31f68d4a477f15c232997c87e270cfffb927459ac/zensical-0.0.24-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:832d4a2a051b9f49561031a2986ace502326f82d9a401ddf125530d30025fdd4", size = 12547616, upload-time = "2026-02-26T09:43:28.031Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/ff/c75ff111b8e12157901d00752beef9d691dbb5a034b6a77359972262416a/zensical-0.0.24-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:e5fea3bb61238dba9f930f52669db67b0c26be98e1c8386a05eb2b1e3cb875dc", size = 12684883, upload-time = "2026-02-26T09:43:30.642Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/92/4f6ea066382e3d068d3cadbed99e9a71af25e46c84a403e0f747960472a2/zensical-0.0.24-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:75eef0428eec2958590633fdc82dc2a58af124879e29573aa7e153b662978073", size = 12713825, upload-time = "2026-02-26T09:43:33.273Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/fb/bf735b19bce0034b1f3b8e1c50b2896ebbd0c5d92d462777e759e78bb083/zensical-0.0.24-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:3c6b39659156394ff805b4831dac108c839483d9efa4c9b901eaa913efee1ac7", size = 12854318, upload-time = "2026-02-26T09:43:35.632Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/28/0ddab6c1237e3625e7763ff666806f31e5760bb36d18624135a6bb6e8643/zensical-0.0.24-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9eef82865a18b3ca4c3cd13e245dff09a865d1da3c861e2fc86eaa9253a90f02", size = 12818270, upload-time = "2026-02-26T09:43:37.749Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/93/d2cef3705d4434896feadffb5b3e44744ef9f1204bc41202c1b84a4eeef6/zensical-0.0.24-cp310-abi3-win32.whl", hash = "sha256:f4d0ff47d505c786a26c9332317aa3e9ad58d1382f55212a10dc5bafcca97864", size = 11857695, upload-time = "2026-02-26T09:43:39.906Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/26/9707587c0f6044dd1e1cc5bc3b9fa5fed81ce6c7bcdb09c21a9795e802d9/zensical-0.0.24-cp310-abi3-win_amd64.whl", hash = "sha256:e00a62cf04526dbed665e989b8f448eb976247f077a76dfdd84699ace4aa3ac3", size = 12057762, upload-time = "2026-02-26T09:43:42.627Z" },
+    { url = "https://files.pythonhosted.org/packages/74/5f/45d5200405420a9d8ac91cf9e7826622ea12f3198e8e6ac4ffb481eb53bf/zensical-0.0.33-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:f658e3c241cfbb560bd8811116a9486cff7e04d7d5aed73569dd533c74187450", size = 12416748, upload-time = "2026-04-14T11:07:43.246Z" },
+    { url = "https://files.pythonhosted.org/packages/33/1e/aadaf31d6e4d20419ecedaf0b1c804e359ec23dcdb44c8d2bf6d8407080c/zensical-0.0.33-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:f9813ac3256c28e2e2f1ba5c9fab1b4bca62bbe0e0f8e85ac22d33b068b1b08a", size = 12293372, upload-time = "2026-04-14T11:07:46.569Z" },
+    { url = "https://files.pythonhosted.org/packages/db/e5/838be8451ea8b2aecec39fbec3971060fc705e17f5741249740d9b6a6824/zensical-0.0.33-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3bad7ac71028769c5d1f3f84f448dbb7352db28d77095d1b40a8d1b0aa34ec30", size = 12659832, upload-time = "2026-04-14T11:07:50.754Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5c/dd957d7c83efc13a70a6058d4190a3afcf29942aefb391120bca5466347d/zensical-0.0.33-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:06bb039daf044547c9400a52f9493b3cd486ba9baef3324fdcffd2e26e61105f", size = 12603847, upload-time = "2026-04-14T11:07:53.698Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/99/dd6ccc392ece1f34fb20ea339a01717badbbeb2fba1d4f3019a5028d0bcc/zensical-0.0.33-cp310-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:260238062b3139ece0edab93f4dbe7a12923453091f5aa580dfd73e799388076", size = 12956236, upload-time = "2026-04-14T11:07:56.728Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/76/e0a1b884eadf6afa7e2d56c90c268eec36836ac27e96ef250c0129e55417/zensical-0.0.33-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7dff0f4afda7b8586bc4ab2a5684bce5b282232dd4e0cad3be4c73fedd264425", size = 12701944, upload-time = "2026-04-14T11:07:59.928Z" },
+    { url = "https://files.pythonhosted.org/packages/38/38/e1ff13461e406864fa2b23fc828822659a7dbac5c79398f724d17f088540/zensical-0.0.33-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:207b4d81b208d75b97dc7bd318804550b886a3e852ef67429ef0e6b9442839d1", size = 12835444, upload-time = "2026-04-14T11:08:02.998Z" },
+    { url = "https://files.pythonhosted.org/packages/41/04/7d24d52d6903fc5c511633afe8b5716fef19da09685327665cc127f61648/zensical-0.0.33-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:06d2f57f7bc8cc8fd904386020ea1365eebc411e8698a871e9525c885abca574", size = 12878419, upload-time = "2026-04-14T11:08:06.054Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/ec/87fc9e360c694ab006363c7834639eccafd0d26a487cd63dd609bd68f36a/zensical-0.0.33-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:c2851b82d83aa0b2ae4f8e99731cfeedeecebfa04e6b3fc4d375deca629fa240", size = 13022474, upload-time = "2026-04-14T11:08:09.007Z" },
+    { url = "https://files.pythonhosted.org/packages/10/b3/0bf174ab6ceedb31d9af462073b5339c894b2084a27d42cb9f0906050d76/zensical-0.0.33-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:90daaf512b0429d7b9147ad5e6085b455d24803eff18b508aed738ca65444683", size = 12975233, upload-time = "2026-04-14T11:08:12.535Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/27/7cc3c2d284698647f60f3b823e0101e619c87edf158d47ee11bf4bfb6228/zensical-0.0.33-cp310-abi3-win32.whl", hash = "sha256:2701820597fe19361a12371129927c58c19633dcaa5f6986d610dce58cecd8c4", size = 12012664, upload-time = "2026-04-14T11:08:14.977Z" },
+    { url = "https://files.pythonhosted.org/packages/25/0b/6be5c2fdaf9f1600577e7ba5e235d86b72a26f6af389efb146f978f76ac3/zensical-0.0.33-cp310-abi3-win_amd64.whl", hash = "sha256:a5a0911b4247708a55951b74c459f4d5faec5daaf287d23a2e1f0d96be1e647f", size = 12206255, upload-time = "2026-04-14T11:08:17.375Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds versioned documentation on [haeo.io](https://haeo.io/): one entry per GitHub release plus a `main` (dev) build, with `latest` pointing at the newest non-rc release.
- Each release now ships its built docs as a `docs.zip` asset, so old versions are built **once** from their own tag and never rebuilt. The main docs workflow downloads those zips and assembles them — no `mike`, no `gh-pages` branch, no Pages settings changes.
- Bumps `zensical>=0.0.30` (adds mike-format `versions.json` UI) and fixes `site_url` to the custom domain.

## What changed

- [`.github/workflows/release.yml`](.github/workflows/release.yml) — new `build-docs` job builds the tag's docs (picking `zensical build` or `mkdocs build` as appropriate) and uploads `docs.zip` alongside `haeo.zip`.
- [`.github/workflows/docs.yml`](.github/workflows/docs.yml) — now triggers on push to `main`, release publication, and `workflow_dispatch`; builds `main` fresh, runs the assembly script, uploads the combined tree as the Pages artifact.
- [`.github/workflows/backfill-release-docs.yml`](.github/workflows/backfill-release-docs.yml) — one-time / ad-hoc `workflow_dispatch` workflow that retro-fits `docs.zip` onto existing releases. Accepts an optional `tag` input to rebuild a single release; without it processes every release missing the asset. Continues past individual build failures.
- [`tools/assemble_docs.py`](tools/assemble_docs.py) — pure-Python stand-in for `mike` that writes `versions.json`, creates `latest/` and `dev/` alias copies, a root meta-refresh redirect, and a `CNAME` for the custom domain.
- [`tests/test_assemble_docs.py`](tests/test_assemble_docs.py) — unit tests for tag parsing, sort order, alias assignment, and redirect HTML.
- [`mkdocs.yml`](mkdocs.yml): `site_url` → `https://haeo.io/`.
- [`pyproject.toml`](pyproject.toml) + `uv.lock`: `zensical>=0.0.30`.

## Caveats

- Tags `v0.1.0`–`v0.4.0rc1` didn't have `extra.version.provider: mike` in their own `mkdocs.yml`, so their built pages won't render the dropdown widget themselves. `versions.json` still lists them and they're reachable at `haeo.io/<version>/`. Future releases from this PR onward carry the provider natively.

## Test plan

- [x] `uv run pytest tests/test_assemble_docs.py` — 8 passing.
- [x] `uv run ruff check tools/assemble_docs.py tests/test_assemble_docs.py` — clean.
- [x] `uv run pyright tools/assemble_docs.py tests/test_assemble_docs.py` — clean.
- [x] Workflow YAML parses (`yaml.safe_load` on all three).
- [x] Dry-run of `tools/assemble_docs.py` against a stub `gh` (no releases) produces the expected `main/`, `dev/`, `versions.json`, `index.html`, `CNAME` layout.
- [ ] Trigger `Backfill Release Docs` manually after merge to populate `docs.zip` on the 9 existing releases.
- [ ] Confirm on [haeo.io](https://haeo.io/) that the version selector shows every release and `latest` redirects to the newest non-rc release.


Made with [Cursor](https://cursor.com)