### PR TITLE
Document min-cut pricing placement and VLAN-to-all-sinks reachability

### DIFF
--- a/docs/developer-guide/policy-compilation.md
+++ b/docs/developer-guide/policy-compilation.md
@@ -49,10 +49,14 @@ This yields the minimum VLAN count for correct policy behavior.
 
 ### Step 4: Reachability analysis
 
-For each VLAN, find connections on directed paths from source nodes to destination nodes.
+For each VLAN, find connections on directed paths from source nodes to *any* sink node — not just the policy's explicit destinations.
 Forward reachability follows connection direction (source → target); backward reachability follows reverse direction (target → source).
 Only connections whose endpoints appear in both the forward and backward reachable sets receive variables for that VLAN.
-This directed approach prevents tags from leaking onto adjacent connections not on a valid policy path.
+This directed approach prevents tags from leaking onto adjacent connections not on a valid source-to-sink path.
+
+Restricting VLAN membership to policy-specific destinations only would force tagged flow to detour through storage (or be curtailed) whenever the source exceeded its policy destination's capacity, because non-destination sinks would refuse the tag.
+That manifests as spurious simultaneous battery charge and discharge — power "laundered" through storage purely to relabel its provenance.
+Pricing is still placed only on the cut separating source from its policy-specific destinations (Step 8), so non-destination sinks remain policy-free.
 
 ### Step 5: Connection tagging
 
@@ -74,8 +78,20 @@ Power on any VLAN can still flow through junction nodes for routing.
 
 ### Step 8: Pricing injection
 
-For each policy, add a scoped pricing segment at the destination connection.
-The segment's `tag` matches the source VLAN.
+For each policy, compute a sink-side canonical minimum s-t cut on the per-VLAN subgraph and attach scoped pricing segments to the connections in that cut.
+Sources of the cut are the policy's source nodes; sinks are the policy's destination nodes.
+The algorithm is Edmonds–Karp max-flow with unit edge capacities; the sink-side canonical cut is recovered from the residual graph by reverse BFS from the super-sink.
+
+Unit capacities and the sink-side choice together guarantee:
+
+- Every source-to-destination path on the VLAN crosses exactly one cut edge, so a unit of tagged flow pays the policy price exactly once.
+    No stacking from overlapping sub-cuts, and no flows that bypass pricing.
+- Minimum cut cardinality, so pricing is attached to the fewest connections possible.
+    This extends cleanly to power-limit policies, which become a single $\sum_{e \in \text{cut}} P^{tag}_{e,t} \le X$ constraint.
+- Natural collapse to intuitive placements: target-inbound edges for a specific destination, source-outbound edges for a single-outbound source targeting a wildcard, and a shared bottleneck (e.g. an inverter) when many sources and many destinations converge through a narrower middle.
+
+A source that also appears in the destination set (e.g. a battery is both source and sink after wildcard expansion) has only the self-loop removed from the destination set; other destinations are still cut normally.
+Each injected segment's `tag` matches the source VLAN, and `price_source_target` and `price_target_source` map from the policy's directional prices.
 
 ## Architecture
 
@@ -105,16 +121,16 @@ Policies:
   Solar -> Load: $0.02/kWh
 ```
 
-| Step             | Result                                                                 |
-| ---------------- | ---------------------------------------------------------------------- |
-| Flow enumeration | {(Grid,Load,0.05), (Solar,Load,0.02)}                                  |
-| Signatures       | Grid and Solar have different signatures; others have empty signatures |
-| VLANs            | Grid=1, Solar=2, others stay on tag 0                                  |
-| Reachability     | VLAN 1 on Grid→SW→Load path, VLAN 2 on Solar→SW→Load path              |
-| Connection tags  | Each connection carries only VLANs for paths through it                |
-| Outbound tags    | Grid emits VLAN 1, Solar emits VLAN 2, Battery emits tag 0             |
-| Inbound tags     | Load accepts tag 0, VLAN 1, and VLAN 2                                 |
-| Pricing          | SW→Load: pricing(tag=grid_vlan,$0.05), pricing(tag=solar_vlan,$0.02)   |
+| Step             | Result                                                                          |
+| ---------------- | ------------------------------------------------------------------------------- |
+| Flow enumeration | {(Grid,Load,0.05), (Solar,Load,0.02)}                                           |
+| Signatures       | Grid and Solar have different signatures; others have empty signatures          |
+| VLANs            | Grid=1, Solar=2, others stay on tag 0                                           |
+| Reachability     | VLAN 1 on connections from Grid to every sink; VLAN 2 on connections from Solar |
+| Connection tags  | Each connection carries only VLANs for paths through it                         |
+| Outbound tags    | Grid emits VLAN 1, Solar emits VLAN 2, Battery emits tag 0                      |
+| Inbound tags     | Load accepts tag 0, VLAN 1, and VLAN 2                                          |
+| Pricing          | Min-cut for each VLAN is SW→Load: pricing(tag=1,$0.05) and pricing(tag=2,$0.02) |
 
 Result: Solar power is preferred over grid power because it has lower policy cost.
 Battery power flows freely on tag 0 at zero policy cost.

--- a/docs/developer-guide/vlan-optimization.md
+++ b/docs/developer-guide/vlan-optimization.md
@@ -41,9 +41,13 @@ That count is the minimum required for a correct policy representation.
 After VLAN assignment, compute which connections actually need each VLAN using directed reachability.
 
 For each non-zero VLAN, identify the source nodes assigned to that VLAN.
-Identify destination nodes that policies target for that VLAN's signature class.
-Compute forward reachability from sources (following connection direction) and backward reachability from destinations (reverse direction).
+Compute forward reachability from those sources (following connection direction) and backward reachability from *all* sink nodes (reverse direction).
 Assign the VLAN only to connections whose endpoints appear in both the forward and backward reachable sets.
+
+Reachability targets every sink in the network, not just the destinations named by policies for that VLAN.
+A policy restricts where tagged flow is *priced* — it does not restrict where tagged flow may physically terminate.
+If the subgraph were narrowed to policy destinations only, a tagged source would be unable to serve an ordinary sink directly whenever the policy destination's capacity was exhausted, and the solver would be forced to launder power through storage to shed the tag.
+Pricing placement (Step 8 of the compilation pipeline) still uses the source-to-policy-destination cut, so non-destination sinks remain policy-free while retaining a direct path.
 
 ### Savings pattern
 
@@ -54,13 +58,14 @@ Assign the VLAN only to connections whose endpoints appear in both the forward a
 | Tree         | $C \times K$          | $K \times avg\_path\_length$ |
 
 Savings are largest when each VLAN only traverses part of the network.
+Expanding targets from policy destinations to all sinks slightly reduces pruning when a source has few policy destinations but many other sinks; the trade-off is sound LP semantics.
 
 ## Combined pipeline
 
 1. Compute policy signatures for all source nodes.
 2. Merge identical signatures into one VLAN assignment map.
 3. Initialize all connections with VLAN 0.
-4. For each non-zero VLAN, run reachability between matched sources and destinations.
+4. For each non-zero VLAN, run reachability between matched sources and all sink nodes.
 5. Add that VLAN only to reachable connections.
 
 ## Worked examples

--- a/docs/modeling/tagged-power.md
+++ b/docs/modeling/tagged-power.md
@@ -165,12 +165,12 @@ When no policies exist at all, only tag 0 exists — identical to standard HAEO.
 For each VLAN, compute which connections can carry it using directed reachability.
 
 1. Identify source nodes assigned to that VLAN.
-2. Identify destination nodes matched by policies for that VLAN.
-3. Compute forward reachability from sources (following connection direction) and backward reachability from destinations (reverse direction).
-4. Assign VLAN variables only to connections whose endpoints both appear in the intersection of forward and backward reachable sets.
+2. Compute forward reachability from those sources (following connection direction) and backward reachability from *all* sink nodes (reverse direction).
+3. Assign VLAN variables only to connections whose endpoints both appear in the intersection of forward and backward reachable sets.
 
-This avoids creating variables on impossible routes.
-Directed reachability prevents tags from leaking onto connections that happen to be adjacent but not on a valid source-to-destination path.
+This avoids creating variables on impossible routes, while also ensuring a tagged source has a direct path to every sink it could physically serve.
+A policy restricts where tagged flow is *priced* (Step 8), not where it may physically terminate: narrowing the subgraph to policy destinations alone would force solar to detour through storage whenever a Solar→Grid policy exhausted grid capacity, because Load would refuse the Solar tag.
+That shows up as spurious simultaneous charge and discharge — power "laundered" through the battery to shed its provenance.
 For tree topologies, which cover most home energy systems, paths between any two nodes are unique and the computation is linear in the node count.
 
 ### Step 5: Connection tagging
@@ -196,11 +196,19 @@ Junction nodes (neither source nor sink) do not receive inbound tags.
 
 ### Step 8: Pricing injection
 
-For each policy, inject a pricing segment at the destination connection.
+For each policy, compute a sink-side canonical minimum s-t cut on the per-VLAN subgraph and attach a scoped pricing segment to each connection in that cut.
+The algorithm is Edmonds–Karp max-flow with unit edge capacities; the cut is recovered by reverse BFS from the super-sink in the residual graph.
 
-- Segment type is `pricing`.
-- Segment `tag` is the source VLAN.
-- Price fields map from `price_source_target` and `price_target_source`.
+Unit capacities and the sink-side choice jointly guarantee that every source-to-destination path on the VLAN crosses exactly one cut edge, so a unit of tagged flow pays the policy price exactly once — no stacking from overlapping sub-cuts, and no flows that bypass pricing.
+Minimum cardinality also means pricing is attached to the fewest connections, which matters for power-limit policies: the limit collapses to a single $\sum_{e \in \text{cut}} P^{tag}_{e,t} \le X$ constraint.
+
+The cut naturally collapses to intuitive placements:
+
+- Target-inbound edges for a specific destination (e.g. `Grid → Load` prices the `SW → Load` connection).
+- Source-outbound edges for a single-outbound source targeting a wildcard (e.g. `Battery → *` prices the single `Battery → Inverter` connection).
+- A shared bottleneck when many sources and many destinations converge through a narrower middle (e.g. an inverter separating `Solar|Battery` from `Load|Grid`).
+
+Each injected segment's `tag` matches the source VLAN, and `price_source_target` and `price_target_source` map from the policy's directional prices.
 
 ## Mathematical formulation
 
@@ -233,10 +241,11 @@ Node balance applies independently for each tag.
 For policy `(source_vlan, destination, price)`, the policy cost contribution is:
 
 $$
-C_{\text{policy}} = \sum_t P^{st}_{v,t} \cdot \pi \cdot \Delta t_t
+C_{\text{policy}} = \sum_{e \in \text{cut}} \sum_t P^{st}_{v,e,t} \cdot \pi \cdot \Delta t_t
 $$
 
-This term is scoped to the source VLAN at the destination connection.
+The sum runs over the sink-side canonical minimum cut separating source from destination on the VLAN subgraph (see Step 8).
+Unit capacities guarantee each source-to-destination path crosses exactly one cut edge, so the term assesses the policy price on each unit of tagged flow exactly once.
 
 ## Variable count analysis
 
@@ -264,10 +273,10 @@ Compilation summary:
 1. Flows: `{(Grid, Load, 0.05)}`.
 2. Signatures: Grid has `{(Load, 0.05)}`, others have empty signatures.
 3. VLANs: Grid gets VLAN 1, others stay on tag 0.
-4. Reachability: VLAN 1 appears only on directed path from Grid to Load.
+4. Reachability: VLAN 1 appears on the directed path from Grid to every sink it can reach (here just Load).
 5. Outbound tags: Grid produces on VLAN 1, Solar produces on tag 0.
 6. Inbound tags: Load accepts tag 0 and VLAN 1.
-7. Pricing: destination connection gets `pricing(tag=grid_vlan, $0.05)`.
+7. Pricing: the min-cut separating Grid from Load collapses to the `SW → Load` inbound edge, which gets `pricing(tag=grid_vlan, $0.05)`.
 
 Result:
 Grid power carries the surcharge to `Load`.
@@ -283,7 +292,7 @@ Policy: Battery -> *: $0.02/kWh
 Battery gets a VLAN with a discharge wear cost.
 Solar and Grid stay on tag 0 (no policy targets them) at zero cost.
 All sink destinations accept tag 0 and Battery's VLAN, so Solar and Grid power reaches them freely.
-Battery power carries the `$0.02/kWh` wear cost everywhere it flows.
+The wildcard destination expands to every sink reachable from Battery, and the min-cut collapses to the single `Battery → Switchboard` outbound edge — one segment carries the `$0.02/kWh` wear cost regardless of which sink ultimately consumes the power.
 
 ## Implementation location
 


### PR DESCRIPTION
## Summary

Follow-up documentation update for #393 (merged). Describes the two compilation-pipeline changes that shipped with that PR.

- **Step 4 (reachability)**: document that VLAN membership follows source provenance to *any* sink, not just policy-specific destinations. Policies restrict where tagged flow is priced, not where it may physically terminate; narrowing the subgraph to policy destinations alone would force solver laundering through storage whenever the policy destination's capacity was exhausted (the ``washing'' behaviour fixed in #393).
- **Step 8 (pricing injection)**: document the sink-side canonical minimum s-t cut (Edmonds-Karp, unit capacities) on the per-VLAN subgraph, replacing the prior ``segment at the destination connection'' wording. The cut guarantees each source-to-destination path crosses exactly one priced edge (no stacking, no bypassed pricing) with minimum cardinality (extends cleanly to power-limit policies).

Also updates:

- Policy cost term formula in `tagged-power.md` to sum over cut edges.
- Worked examples to describe the collapsed cut placement (e.g. `Battery → *` collapses to the single `Battery → Switchboard` outbound edge; `Grid → Load` collapses to the `SW → Load` inbound edge).

Files:

- `docs/developer-guide/policy-compilation.md`
- `docs/developer-guide/vlan-optimization.md`
- `docs/modeling/tagged-power.md`

## Test plan

- [x] `uv run mdformat --check` on all tracked markdown.
- [ ] Visual review that the updated wording matches the implementation in `custom_components/haeo/core/adapters/policy_compilation.py` (Step 4 `reach_targets = sink_names`, Step 8 `_min_cut_edges`).


Made with [Cursor](https://cursor.com)