### PR TITLE
Absorb VLAN tags at sinks and exclude edges into a VLAN's own source

### DIFF
--- a/custom_components/haeo/core/adapters/policy_compilation.py
+++ b/custom_components/haeo/core/adapters/policy_compilation.py
@@ -321,7 +321,7 @@ def _find_reachable_connections(
         start_nodes: set[str],
         adjacency: Mapping[str, set[tuple[str, str]]],
         *,
-        stop_at: set[str] = frozenset(),
+        stop_at: frozenset[str] | set[str] = frozenset(),
     ) -> tuple[set[str], set[str]]:
         """Return (reachable, expanded) where expanded excludes stop_at nodes."""
         reachable: set[str] = set()

--- a/custom_components/haeo/core/adapters/policy_compilation.py
+++ b/custom_components/haeo/core/adapters/policy_compilation.py
@@ -146,18 +146,24 @@ def compile_policies(
 
     # --- Step 4: Reachability analysis ---
     # VLAN membership follows source provenance: a VLAN covers every
-    # connection on a directed path from the VLAN's sources to *any* sink.
+    # connection on a directed path from the VLAN's sources to *any* sink,
+    # stopping at each sink (sinks absorb the VLAN).
     #
-    # Restricting to policy destinations alone would force tagged flow to
-    # detour through a battery (or curtail) whenever the source exceeds
-    # the policy destination's capacity, because non-destination sinks
-    # would refuse the VLAN tag. Pricing is still only placed on the cut
-    # separating source from policy-specific destinations (step 8);
-    # non-destination sinks remain policy-free.
+    # Reaching every sink (not just policy destinations) is necessary so
+    # excess flow has somewhere to go without detouring or being curtailed
+    # whenever the source exceeds the policy destination's capacity.
+    # Absorbing at sinks prevents phantom passthrough where a storage
+    # element (battery) would otherwise allow tagged flow to enter and
+    # re-emerge on its outbound edge, laundering provenance and exposing
+    # zero-wear arbitrage loops against tag-scoped prices. Pricing is
+    # still only placed on the cut separating source from policy-specific
+    # destinations (step 8); non-destination sinks remain policy-free.
     vlan_connections: dict[int, set[str]] = {}
     for vlan_id in active_vlans:
         source_nodes = {n for n, v in tag_map.items() if v == vlan_id}
-        vlan_connections[vlan_id] = _find_reachable_connections(source_nodes, sink_names, directed_graph)
+        vlan_connections[vlan_id] = _find_reachable_connections(
+            source_nodes, sink_names, directed_graph, absorb_at=sink_names
+        )
 
     # --- Step 5: Connection tagging ---
     for conn in connections:
@@ -270,6 +276,7 @@ def _find_reachable_connections(
     source_nodes: set[str],
     dest_nodes: set[str],
     directed_graph: Mapping[str, set[tuple[str, str]]],
+    absorb_at: set[str] | None = None,
 ) -> set[str]:
     """Find connections on directed paths from source_nodes to dest_nodes.
 
@@ -278,10 +285,31 @@ def _find_reachable_connections(
     direction (target → source). Only connections whose endpoints both appear
     in the intersection of forward and backward reachable sets are included.
 
+    When ``absorb_at`` is provided (typically the set of sink nodes), the
+    forward traversal treats those nodes as absorbing: flow may reach them
+    but does not continue out of them. This is what gives storage elements
+    "tag-absorbing" semantics — a VLAN that reaches a battery does not
+    propagate onto that battery's outbound connections, so downstream flow
+    is tagged with the battery's own provenance rather than passing
+    through. Nodes in ``source_nodes`` are exempt from absorption so the
+    VLAN's own sources can still expand outward. Backward traversal is
+    unaffected, so sinks on the destination side still trace their way
+    back to the appropriate sources.
+
+    Edges whose target lies in ``source_nodes`` are excluded from the
+    result: a VLAN represents power *originating* at its source, so
+    tagged flow must not re-enter that source.  Including such edges on
+    a storage element (battery that is both source and sink for its own
+    VLAN) creates a zero-cost self-loop — Battery:discharge → Inverter →
+    Battery:charge → Battery — that bypasses every downstream cut and
+    exposes arbitrage whenever an inbound edge pays an incentive.
+
     Stays linear in graph size and is stable on cyclic topologies.
     """
     if not source_nodes or not dest_nodes:
         return set()
+
+    absorbing = (absorb_at or set()) - source_nodes
 
     # Build reverse directed graph
     reverse_graph: dict[str, set[tuple[str, str]]] = defaultdict(set)
@@ -289,31 +317,45 @@ def _find_reachable_connections(
         for neighbor, conn_name in neighbors:
             reverse_graph[neighbor].add((current, conn_name))
 
-    def collect_reachable(start_nodes: set[str], adjacency: Mapping[str, set[tuple[str, str]]]) -> set[str]:
+    def collect_reachable(
+        start_nodes: set[str],
+        adjacency: Mapping[str, set[tuple[str, str]]],
+        *,
+        stop_at: set[str] = frozenset(),
+    ) -> tuple[set[str], set[str]]:
+        """Return (reachable, expanded) where expanded excludes stop_at nodes."""
         reachable: set[str] = set()
+        expanded: set[str] = set()
         queue: deque[str] = deque(start_nodes)
         while queue:
             current = queue.popleft()
             if current in reachable:
                 continue
             reachable.add(current)
+            if current in stop_at:
+                continue
+            expanded.add(current)
             for neighbor, _conn_name in adjacency.get(current, set()):
                 if neighbor not in reachable:
                     queue.append(neighbor)
-        return reachable
+        return reachable, expanded
 
-    forward_reachable = collect_reachable(source_nodes, directed_graph)
-    backward_reachable = collect_reachable(dest_nodes, reverse_graph)
+    forward_reachable, forward_expanded = collect_reachable(source_nodes, directed_graph, stop_at=absorbing)
+    backward_reachable, _ = collect_reachable(dest_nodes, reverse_graph)
 
     relevant_nodes = forward_reachable & backward_reachable
     if not relevant_nodes:
         return set()
 
+    # Only emit edges out of nodes we actually expanded forward; edges out
+    # of absorbing nodes are excluded so tags stop at the sink.  Edges
+    # whose target is the VLAN's own source are also excluded, so tagged
+    # flow cannot re-enter its origin and create phantom storage loops.
     return {
         conn_name
-        for current in relevant_nodes
+        for current in relevant_nodes & forward_expanded
         for neighbor, conn_name in directed_graph.get(current, set())
-        if neighbor in relevant_nodes
+        if neighbor in relevant_nodes and neighbor not in source_nodes
     }
 
 

--- a/custom_components/haeo/core/adapters/policy_compilation.py
+++ b/custom_components/haeo/core/adapters/policy_compilation.py
@@ -22,6 +22,7 @@ See docs/developer-guide/vlan-optimization.md for optimization proofs.
 
 from collections import defaultdict, deque
 from collections.abc import Mapping, Sequence
+from collections.abc import Set as AbstractSet
 from typing import Any, NotRequired, TypedDict
 
 import numpy as np
@@ -321,7 +322,7 @@ def _find_reachable_connections(
         start_nodes: set[str],
         adjacency: Mapping[str, set[tuple[str, str]]],
         *,
-        stop_at: frozenset[str] | set[str] = frozenset(),
+        stop_at: AbstractSet[str] = frozenset(),
     ) -> tuple[set[str], set[str]]:
         """Return (reachable, expanded) where expanded excludes stop_at nodes."""
         reachable: set[str] = set()

--- a/custom_components/haeo/core/adapters/tests/test_policy_compilation.py
+++ b/custom_components/haeo/core/adapters/tests/test_policy_compilation.py
@@ -788,7 +788,7 @@ def test_pricing_injection_skips_non_tagged_incident_connections(
     monkeypatch.setattr(
         policy_compilation,
         "_find_reachable_connections",
-        lambda _source_nodes, _dest_nodes, _graph: {"source_dest"},
+        lambda _source_nodes, _dest_nodes, _graph, **_kwargs: {"source_dest"},
     )
     policies = [{"sources": ["source"], "destinations": ["dest"], "price": 0.07}]
     result = compile_policies(elements, policies)
@@ -837,6 +837,129 @@ def test_find_reachable_connections_returns_empty_for_disjoint_reachability() ->
         "y": {("x", "xy")},
     }
     assert _find_reachable_connections({"a"}, {"y"}, graph) == set()
+
+
+def test_find_reachable_connections_absorbs_tags_at_sinks() -> None:
+    """Tags stop propagating at sink nodes (storage-style absorbing semantics).
+
+    With ``absorb_at`` supplied, forward reachability treats those nodes as
+    dead-ends: flow may arrive but does not continue out. This prevents a
+    battery (which is both a source and a sink) from laundering an incoming
+    VLAN onto its outbound edge, where the tag would bypass costs that were
+    placed on the battery's own VLAN.
+    """
+    # solar → inv → battery → inv → load : without absorption the VLAN
+    # from solar would propagate onto battery's outbound edge as well.
+    graph = {
+        "solar": {("inv", "solar_inv")},
+        "inv": {("battery", "battery_charge"), ("load", "inv_load")},
+        "battery": {("inv", "battery_discharge")},
+    }
+    sinks = {"battery", "load"}
+    connections = _find_reachable_connections({"solar"}, sinks, graph, absorb_at=sinks)
+    assert "battery_discharge" not in connections
+    # Still reaches load directly and the battery charge edge
+    assert "solar_inv" in connections
+    assert "inv_load" in connections
+    assert "battery_charge" in connections
+
+
+def test_find_reachable_connections_does_not_absorb_at_origin() -> None:
+    """Origin sources always expand even if they are in the absorbing set.
+
+    A battery's own VLAN must propagate forward from the battery (it is both
+    a source and a sink). Including the origin in ``absorb_at`` would
+    otherwise stop expansion before it started.
+    """
+    graph = {
+        "battery": {("inv", "battery_discharge")},
+        "inv": {("load", "inv_load")},
+    }
+    sinks = {"battery", "load"}
+    connections = _find_reachable_connections({"battery"}, sinks, graph, absorb_at=sinks)
+    assert connections == {"battery_discharge", "inv_load"}
+
+
+def test_find_reachable_connections_excludes_edges_into_source() -> None:
+    """Tagged flow cannot re-enter its own source node.
+
+    A battery is both a source and a sink for its own VLAN.  Without this
+    exclusion the reachable edge set includes ``Battery:charge`` for the
+    battery VLAN, creating a zero-cost self-loop (discharge → inverter →
+    charge → battery) that bypasses every downstream cut where the wear
+    cost lives.  Excluding edges whose target is the VLAN's own source
+    breaks the loop without affecting legitimate source→sink flow.
+    """
+    # battery → inv → battery forms a self-loop via the charge edge
+    graph = {
+        "battery": {("inv", "battery_discharge")},
+        "inv": {("battery", "battery_charge"), ("load", "inv_load")},
+    }
+    sinks = {"battery", "load"}
+    connections = _find_reachable_connections({"battery"}, sinks, graph, absorb_at=sinks)
+    assert "battery_charge" not in connections, (
+        "Battery VLAN must not re-enter the battery via its charge edge; "
+        "otherwise solver exploits a zero-cost self-loop."
+    )
+    assert "battery_discharge" in connections
+    assert "inv_load" in connections
+
+
+def test_compile_policies_excludes_battery_self_loop_vlan() -> None:
+    """Integration: the battery's own VLAN does not tag its charge edge.
+
+    Closes the zero-wear phantom cycle (Battery:discharge → Inverter →
+    Battery:charge → Battery) that would otherwise let solar charge
+    incentives fund efficiency-loss losses while sidestepping wear.
+    """
+    elements = [
+        _node("solar", is_source=True),
+        _node("battery", is_source=True, is_sink=True),
+        _node("load", is_sink=True),
+        _junction("inv"),
+        _conn("solar_inv", "solar", "inv"),
+        _conn("battery_charge", "inv", "battery"),
+        _conn("battery_discharge", "battery", "inv"),
+        _conn("inv_load", "inv", "load"),
+    ]
+    policies = [
+        {"sources": ["solar"], "destinations": ["battery"], "price": -0.001},
+        {"sources": ["battery"], "destinations": ["*"], "price": 0.01},
+    ]
+    result = compile_policies(elements, policies)
+    conns = {c["name"]: c for c in _connections(result)}
+    battery_tag = next(iter((conns["battery_discharge"].get("tags") or set()) - {0}))
+    charge_tags = conns["battery_charge"].get("tags") or set()
+    assert battery_tag not in charge_tags, "Battery's own VLAN must not tag its own charge edge."
+
+
+def test_compile_policies_absorbs_solar_tag_at_battery_sink() -> None:
+    """Integration: Solar-tagged flow cannot re-emerge from a battery.
+
+    This closes a phantom-arbitrage loop where Solar→Battery:charge with a
+    negative charge-incentive could round-trip through Battery:discharge
+    while paying no cost, because the battery's wear cut priced only its
+    own VLAN.
+    """
+    elements = [
+        _node("solar", is_source=True),
+        _node("battery", is_source=True, is_sink=True),
+        _node("load", is_sink=True),
+        _junction("inv"),
+        _conn("solar_inv", "solar", "inv"),
+        _conn("battery_charge", "inv", "battery"),
+        _conn("battery_discharge", "battery", "inv"),
+        _conn("inv_load", "inv", "load"),
+    ]
+    policies = [
+        {"sources": ["solar"], "destinations": ["battery"], "price": -0.001},
+        {"sources": ["battery"], "destinations": ["*"], "price": 0.01},
+    ]
+    result = compile_policies(elements, policies)
+    conns = {c["name"]: c for c in _connections(result)}
+    solar_tag = next(iter((conns["solar_inv"].get("tags") or set()) - {0}))
+    discharge_tags = conns["battery_discharge"].get("tags") or set()
+    assert solar_tag not in discharge_tags, "Solar VLAN must not reach battery discharge"
 
 
 # --- Min-cut placement ---

--- a/docs/developer-guide/policy-compilation.md
+++ b/docs/developer-guide/policy-compilation.md
@@ -58,6 +58,17 @@ Restricting VLAN membership to policy-specific destinations only would force tag
 That manifests as spurious simultaneous battery charge and discharge — power "laundered" through storage purely to relabel its provenance.
 Pricing is still placed only on the cut separating source from its policy-specific destinations (Step 8), so non-destination sinks remain policy-free.
 
+Forward reachability is *sink-absorbing*: when traversal arrives at a sink node, the sink is included in the reachable set but expansion does not continue out of it.
+Without absorption a storage node (both a source and a sink — a battery) would let any incoming VLAN propagate onto its outbound connections, where the tag would bypass any cost placed on the battery's own VLAN.
+The same mechanism powered a phantom charge/discharge arbitrage when a negative-priced charge incentive was paired with a tag-scoped wear cost: the solver could pump tagged flow through the battery at its rate limits, pay only the incentive, and skip the wear because wear lived on a different tag.
+Absorbing at sinks eliminates that degree of freedom entirely — the battery's outbound flow now always carries provenance from the battery's own VLAN, so wear (and any other battery-source policy) always applies.
+The VLAN's source nodes are exempt from absorption so a storage element's own VLAN can still expand outward from it normally.
+
+Reachability additionally excludes edges whose *target* is one of the VLAN's own source nodes.
+A VLAN represents power originating at its sources, so tagged flow must never re-enter its origin.
+For a battery (both a source and a sink of its own VLAN) this removes the `Battery:charge` edge from the battery VLAN: the zero-cost self-loop `Battery:discharge → Inverter → Battery:charge → Battery` is no longer expressible in the tagged graph.
+Without this exclusion the solver could use solar (or any other incoming VLAN) just to cover the round-trip efficiency loss of a battery self-cycle, funding it with the incoming charge incentive while the wear cost — placed on an outbound cut the loop never crosses — is completely avoided.
+
 ### Step 5: Connection tagging
 
 Apply reachability results so each connection gets the set of VLANs that can traverse it.

--- a/docs/developer-guide/vlan-optimization.md
+++ b/docs/developer-guide/vlan-optimization.md
@@ -49,6 +49,10 @@ A policy restricts where tagged flow is *priced* — it does not restrict where 
 If the subgraph were narrowed to policy destinations only, a tagged source would be unable to serve an ordinary sink directly whenever the policy destination's capacity was exhausted, and the solver would be forced to launder power through storage to shed the tag.
 Pricing placement (Step 8 of the compilation pipeline) still uses the source-to-policy-destination cut, so non-destination sinks remain policy-free while retaining a direct path.
 
+Forward reachability is also *sink-absorbing* and *source-excluding*: traversal stops at each sink (except the VLAN's own sources), and edges whose target is one of the VLAN's own sources are dropped.
+Together these rules mean a tag never leaves a sink, never re-enters its origin, and therefore cannot be laundered through storage to avoid tag-scoped pricing.
+See [Node roles and policy scope](../modeling/tagged-power.md#node-roles-and-policy-scope) for the user-facing framing and [Step 4](policy-compilation.md#step-4-reachability-analysis) of the compilation pipeline for the implementation.
+
 ### Savings pattern
 
 | Topology     | Naive variable factor | With pruning                 |

--- a/docs/modeling/tagged-power.md
+++ b/docs/modeling/tagged-power.md
@@ -166,11 +166,14 @@ For each VLAN, compute which connections can carry it using directed reachabilit
 
 1. Identify source nodes assigned to that VLAN.
 2. Compute forward reachability from those sources (following connection direction) and backward reachability from *all* sink nodes (reverse direction).
+   Forward traversal *absorbs* at sink nodes: a sink is included in the reachable set but expansion does not continue out of it. The VLAN's own sources are exempt so storage elements can still expand their own VLAN forward.
 3. Assign VLAN variables only to connections whose endpoints both appear in the intersection of forward and backward reachable sets.
 
 This avoids creating variables on impossible routes, while also ensuring a tagged source has a direct path to every sink it could physically serve.
 A policy restricts where tagged flow is *priced* (Step 8), not where it may physically terminate: narrowing the subgraph to policy destinations alone would force solar to detour through storage whenever a Solar→Grid policy exhausted grid capacity, because Load would refuse the Solar tag.
 That shows up as spurious simultaneous charge and discharge — power "laundered" through the battery to shed its provenance.
+Sink absorption closes a related hole: without it, a VLAN that reached a battery would also propagate onto the battery's outbound edge, letting foreign tags leave storage without paying costs that were priced on the battery's own VLAN — the phantom charge/discharge arbitrage that appears when a negative-priced charge incentive is paired with tag-scoped wear.
+Reachability also excludes edges whose *target* is one of the VLAN's own sources: a VLAN cannot re-enter its origin, which breaks the zero-cost self-loop `Battery:discharge → Inverter → Battery:charge → Battery` that would otherwise let solar (or any other incoming VLAN) pay only for the round-trip efficiency loss while the wear cost on the outbound cut is never crossed.
 For tree topologies, which cover most home energy systems, paths between any two nodes are unique and the computation is linear in the node count.
 
 ### Step 5: Connection tagging

--- a/docs/modeling/tagged-power.md
+++ b/docs/modeling/tagged-power.md
@@ -55,6 +55,76 @@ The data plane (the LP model) executes those rules without understanding the pol
 
 ## Semantics
 
+### Node roles and policy scope
+
+Every element in a HAEO network is classified by two independent flags: `is_source` (can produce power) and `is_sink` (can consume power).
+The combination determines how policy tags flow through the element, which in turn determines where policies apply.
+
+| Role         | `is_source` | `is_sink` | Example elements            | Tag behaviour                                  |
+| ------------ | ----------- | --------- | --------------------------- | ---------------------------------------------- |
+| **Source**   | `true`      | `false`   | Solar                       | Originates its own tag                         |
+| **Sink**     | `false`     | `true`    | Load, Grid-export-only      | Terminates any tag arriving at it              |
+| **Storage**  | `true`      | `true`    | Battery, Grid (bi-dir)      | Originates its own tag *and* terminates others |
+| **Junction** | `false`     | `false`   | Inverter, Switchboard, Node | Passes every tag through unchanged             |
+
+The operative rule is: **sinks terminate provenance**.
+When tagged power arrives at a sink, the tag stops there.
+If the sink is also a source (storage), it re-emits power on *its own* tag, not on whatever tag it received.
+Only junctions — elements that are neither source nor sink — pass tags through unchanged.
+
+This directly constrains what a policy can price:
+
+- A policy with `source=X` can only price edges on the path *from X to the nearest sink it reaches*.
+- If some other sink sits between X and the policy's named destination, the policy does not follow the energy past that intermediate sink.
+- The energy still flows, just under a new tag — whatever provenance the intermediate sink emits as, or the default tag 0 if it is a pure sink.
+
+!!! example "Worked consequence"
+
+    ```
+    Solar → Switchboard → Load → ???
+    ```
+
+    A policy `Solar → *: $0.01/kWh` prices the Solar-tagged flow up to Load (Load is a sink — the tag terminates).
+    There is no "onward" flow downstream of a pure Load.
+
+    ```
+    Solar → Switchboard → Battery → Switchboard → Grid
+    ```
+
+    A policy `Solar → Grid: $0.02/kWh` prices the Solar → Battery leg only.
+    Once energy is stored, it is "Battery power" — any onward pricing must come from a `Battery → Grid` policy, not from the `Solar → Grid` one.
+    This is what prevents the optimiser from "laundering" solar through the battery to dodge a per-source tariff.
+
+### Choosing roles when building a system
+
+When you are modelling a new topology, the decision tree for each element is:
+
+1. **Does it generate or consume real energy?**
+    - Generates → source (Solar, Grid-import).
+    - Consumes → sink (Load, Grid-export).
+    - Stores → both (Battery, bidirectional Grid).
+    - Neither → junction (Inverter, Switchboard, Node with `is_source=false, is_sink=false`).
+2. **Do you want a policy to follow the energy past this point?**
+    - If yes, it must be a junction.
+    - If no, it must be a sink (storage counts).
+
+A common modelling mistake is using a battery or a load as a routing hub.
+Because sinks terminate provenance, any policy that was supposed to price downstream flow will no longer apply past that element.
+If you genuinely need a routing hub, model it as a plain `Node` element with both flags off and attach the real sink/source element beside it:
+
+```mermaid
+graph LR
+    Solar[Solar] --> Switchboard[Switchboard Node]
+    Switchboard --> Load[Load]
+    Switchboard --> Grid[Grid]
+    Switchboard --> Battery[Battery]
+```
+
+Here the Switchboard is a junction, so a `Solar → Grid` policy's tag can travel all the way to the Grid edge.
+Battery and Load sit beside the junction, each with their own tag provenance.
+
+See [Node element configuration](../user-guide/elements/node.md#source-and-sink-combinations) for practical examples.
+
 ### Default behavior without policies
 
 When no policies are configured, behavior matches standard HAEO.
@@ -166,7 +236,7 @@ For each VLAN, compute which connections can carry it using directed reachabilit
 
 1. Identify source nodes assigned to that VLAN.
 2. Compute forward reachability from those sources (following connection direction) and backward reachability from *all* sink nodes (reverse direction).
-   Forward traversal *absorbs* at sink nodes: a sink is included in the reachable set but expansion does not continue out of it. The VLAN's own sources are exempt so storage elements can still expand their own VLAN forward.
+    Forward traversal *absorbs* at sink nodes: a sink is included in the reachable set but expansion does not continue out of it. The VLAN's own sources are exempt so storage elements can still expand their own VLAN forward.
 3. Assign VLAN variables only to connections whose endpoints both appear in the intersection of forward and backward reachable sets.
 
 This avoids creating variables on impossible routes, while also ensuring a tagged source has a direct path to every sink it could physically serve.

--- a/docs/modeling/tagged-power.md
+++ b/docs/modeling/tagged-power.md
@@ -1,411 +1,159 @@
 # Power policies
 
-Power policies control how energy flows through the HAEO network based on provenance.
-They define which sources can reach which destinations, at what cost, and with what limits.
+Power policies attach provenance to power flow so the optimizer can distinguish costs and limits that depend on where the energy originates.
+This page describes the modelling framework: the abstract structure, the mathematical formulation, and the algorithm that turns a set of policy rules into a linear program.
+
+See [policy compilation](../developer-guide/policy-compilation.md) for the concrete compilation pipeline and [VLAN optimization](../developer-guide/vlan-optimization.md) for the pruning algorithms used in production.
 
 ## Motivation
 
-Standard HAEO minimizes total cost without tracking where power originates.
-A kilowatt from the grid is indistinguishable from a kilowatt from solar once it enters the network.
-That behavior is often sufficient for simple systems.
-Real-world energy economics can still depend on provenance.
+A plain energy LP minimises total cost without tracking provenance.
+Once power enters the network it is fungible: a kilowatt-hour from the grid is indistinguishable from a kilowatt-hour from local generation, and the solver is free to substitute one for the other.
+That suffices for systems whose economics depend only on total energy,
+but many real tariffs, constraints and internal valuations are explicitly source-aware.
 
-- **Network usage charges**: Grid power can incur distribution fees that local generation does not.
-- **Feed-in tariffs**: Export rates can differ by source.
-- **Demand constraints**: Some destinations should only draw from specific sources.
-- **Battery wear valuation**: Battery-sourced power can carry an internal cycling cost.
-
-Policies add provenance tracking so the optimizer can make source-aware decisions.
+Network charges, feed-in tariffs and storage wear valuations all share a common shape:
+the applicable price or limit depends on the history of a particular unit of energy, not only on where it is currently flowing.
+Power policies introduce that history as a multi-commodity flow: every distinguishable provenance becomes its own commodity ("tag"), and policies scope prices and limits to the flow of specific tags across specific sub-networks.
 
 ## Design inspiration
 
-The policy system borrows concepts from networking, where tagged flow control is well established.
-
-### VLAN analogy
-
-Power policies use integer tags that are analogous to VLAN IDs in Ethernet.
-
-| Network concept  | HAEO equivalent          | Purpose                                  |
-| ---------------- | ------------------------ | ---------------------------------------- |
-| VLAN ID          | Power tag (integer)      | Identifies power provenance              |
-| Trunk port       | Interior connection      | Carries multiple tags between nodes      |
-| Access port      | Endpoint connection      | Node produces or consumes specific tags  |
-| VLAN access list | Node inbound tags        | Defines which tags a node can consume    |
-| Firewall rule    | Policy rule              | Prices specific source-destination flows |
-| Default allow    | Implicit policy behavior | No policy means free flow on tag 0       |
-
-### Multi-commodity flow
-
-Tagged power flow is a multi-commodity flow formulation.
-Each tag acts as a separate commodity with its own flow variables.
-All commodities share the same physical network capacities.
-This is a standard LP formulation that HiGHS solves natively.
-
-### MPLS label optimization
-
-VLAN assignment is inspired by MPLS label optimization.
-Flows with identical treatment can share labels in MPLS.
-HAEO applies the same principle by letting sources with identical policy signatures share a tag.
-
-### SDN and OpenFlow
-
-The compilation pipeline mirrors software-defined networking patterns.
-A central controller (the compilation step) derives flow rules from high-level policies and installs them on switches (connections and nodes).
-The data plane (the LP model) executes those rules without understanding the policies themselves.
+The formulation borrows concepts from tagged-flow control in packet networks.
+Each tag is analogous to a VLAN identifier: a label carried alongside a flow that partitions physical network capacity into logical per-tag flows, sharing underlying edges but with independent balance and capacity accounting on each edge.
+Tag assignment follows the optimisation principle behind MPLS label merging — flows that receive identical treatment from every downstream rule can share a label without loss of information — so provenance is tracked at the granularity of distinguishable treatment rather than per individual source.
+Policy compilation itself plays the role of an SDN controller: it derives per-edge per-tag flow rules from the high-level policy set and emits them as constraints on the LP, which remains unaware of the policies themselves.
 
 ## Semantics
 
 ### Node roles and policy scope
 
-Every element in a HAEO network is classified by two independent flags: `is_source` (can produce power) and `is_sink` (can consume power).
-The combination determines how policy tags flow through the element, which in turn determines where policies apply.
+Every node has two independent capability bits: whether it can emit power (*source-capable*) and whether it can absorb power (*sink-capable*).
+Their combination determines how tags flow through the node.
 
-| Role         | `is_source` | `is_sink` | Example elements            | Tag behaviour                                  |
-| ------------ | ----------- | --------- | --------------------------- | ---------------------------------------------- |
-| **Source**   | `true`      | `false`   | Solar                       | Originates its own tag                         |
-| **Sink**     | `false`     | `true`    | Load, Grid-export-only      | Terminates any tag arriving at it              |
-| **Storage**  | `true`      | `true`    | Battery, Grid (bi-dir)      | Originates its own tag *and* terminates others |
-| **Junction** | `false`     | `false`   | Inverter, Switchboard, Node | Passes every tag through unchanged             |
+- A source-capable, non-sink node originates its assigned tag and carries no other tag inbound.
+- A sink-capable, non-source node terminates every tag that reaches it.
+- A node with both capabilities originates its own tag and terminates every other tag that reaches it.
+- A node with neither capability is a *junction* that passes every tag through unchanged.
 
-The operative rule is: **sinks terminate provenance**.
-When tagged power arrives at a sink, the tag stops there.
-If the sink is also a source (storage), it re-emits power on *its own* tag, not on whatever tag it received.
-Only junctions — elements that are neither source nor sink — pass tags through unchanged.
+The operative rule is **a sink terminates every tag that is not its own**.
+Tagged flow that reaches a sink is consumed there; any power that continues onward from the same node re-originates under a new tag determined by that node's own source capability, or under the default tag if it has none.
 
-This directly constrains what a policy can price:
-
-- A policy with `source=X` can only price edges on the path *from X to the nearest sink it reaches*.
-- If some other sink sits between X and the policy's named destination, the policy does not follow the energy past that intermediate sink.
-- The energy still flows, just under a new tag — whatever provenance the intermediate sink emits as, or the default tag 0 if it is a pure sink.
-
-!!! example "Worked consequence"
-
-    ```
-    Solar → Switchboard → Load → ???
-    ```
-
-    A policy `Solar → *: $0.01/kWh` prices the Solar-tagged flow up to Load (Load is a sink — the tag terminates).
-    There is no "onward" flow downstream of a pure Load.
-
-    ```
-    Solar → Switchboard → Battery → Switchboard → Grid
-    ```
-
-    A policy `Solar → Grid: $0.02/kWh` prices the Solar → Battery leg only.
-    Once energy is stored, it is "Battery power" — any onward pricing must come from a `Battery → Grid` policy, not from the `Solar → Grid` one.
-    This is what prevents the optimiser from "laundering" solar through the battery to dodge a per-source tariff.
-
-### Choosing roles when building a system
-
-When you are modelling a new topology, the decision tree for each element is:
-
-1. **Does it generate or consume real energy?**
-    - Generates → source (Solar, Grid-import).
-    - Consumes → sink (Load, Grid-export).
-    - Stores → both (Battery, bidirectional Grid).
-    - Neither → junction (Inverter, Switchboard, Node with `is_source=false, is_sink=false`).
-2. **Do you want a policy to follow the energy past this point?**
-    - If yes, it must be a junction.
-    - If no, it must be a sink (storage counts).
-
-A common modelling mistake is using a battery or a load as a routing hub.
-Because sinks terminate provenance, any policy that was supposed to price downstream flow will no longer apply past that element.
-If you genuinely need a routing hub, model it as a plain `Node` element with both flags off and attach the real sink/source element beside it:
-
-```mermaid
-graph LR
-    Solar[Solar] --> Switchboard[Switchboard Node]
-    Switchboard --> Load[Load]
-    Switchboard --> Grid[Grid]
-    Switchboard --> Battery[Battery]
-```
-
-Here the Switchboard is a junction, so a `Solar → Grid` policy's tag can travel all the way to the Grid edge.
-Battery and Load sit beside the junction, each with their own tag provenance.
-
-See [Node element configuration](../user-guide/elements/node.md#source-and-sink-combinations) for practical examples.
-
-### Default behavior without policies
-
-When no policies are configured, behavior matches standard HAEO.
-All connections carry only tag 0.
-Power is fungible and provenance is not tracked.
+This rule constrains the subgraph over which a policy can apply prices.
+A policy extends only through the subgraph reachable from its sources up to the nearest sinks.
+Intermediate sinks absorb the tag, and legs downstream of such a sink fall under the provenance of that intermediate node instead.
+For a tag to traverse a routing node on its way to a downstream destination, the routing node must therefore be a junction.
 
 ### Default-allow model
 
-Policies add costs to specific flows.
-Flows without a matching policy are unrestricted.
-
-- **Policied sources**: Assigned a VLAN and forced onto it via `outbound_tags`. Their power carries the configured policy costs at the destination.
-- **Unpolicied sources**: Produce on tag 0 (the default tag) at zero policy cost.
-- **Sink nodes**: Accept all active VLANs plus tag 0, so both policied and unpolicied power can reach any sink.
-- **Wildcard matching**: `sources: ["*"]` or `destinations: ["*"]` matches capability-appropriate nodes (sources or sinks respectively).
-
-This model avoids creating unnecessary VLANs for unpolicied flows.
-Only sources with explicit policies receive non-zero tags.
+In the absence of any policy, every connection carries a single default tag and the formulation coincides with the untagged LP.
+Introducing policies adds tags only where provenance is distinguishable; unpolicied flow continues on the default tag at zero policy cost.
+Sinks admit both default-tagged flow and every active policy tag, so adding a policy cannot make a previously-feasible schedule infeasible.
 
 ### Policy stacking
 
-Policies are additive.
-When multiple policies match the same source-destination pair, all matching rules apply.
-
-- **Pricing**: Matching prices sum — Battery paying `$0.05` (group policy) and `$0.03` (individual policy) pays `$0.08` total.
-- **Limits**: Matching constraints all apply, and the effective limit is their combined feasible region.
-
-Policies do not override one another.
-A specific policy stacks on top of broader policies.
-
-```
-Policy 1: Battery+Solar -> Load: $0.05/kWh   (group)
-Policy 2: Battery -> Load: $0.03/kWh         (individual)
-```
-
-| Source          | Policies matched    | Total price |
-| --------------- | ------------------- | ----------- |
-| Solar -> Load   | Policy 1            | `$0.05/kWh` |
-| Battery -> Load | Policy 1 + Policy 2 | `$0.08/kWh` |
-
-Battery and solar receive different VLANs because their signatures differ.
-Each VLAN gets all applicable pricing segments.
+Policies that match overlapping source-destination pairs combine *additively* on each matching flow.
+Prices sum, and limits apply as the intersection of feasible regions.
+This falls out of each policy contributing an independent pricing or capacity term to the LP, with no override relationship between them:
+a specific rule therefore layers on top of a broader rule without restating it.
 
 ### Group constraints
 
-Policies that target source groups constrain the sum of those source VLANs.
-Policies that target one source constrain one VLAN.
-Both kinds can coexist.
-
-```
-Policy 1: Battery+Solar -> Load: limit 5 kW
-Policy 2: Battery -> Load: limit 2 kW
-```
-
-| Constraint | Tags                        | Limit     |
-| ---------- | --------------------------- | --------- |
-| Group      | `VLAN_solar + VLAN_battery` | `<= 5 kW` |
-| Individual | `VLAN_battery`              | `<= 2 kW` |
-
-Result: Solar can draw up to 5 kW, Battery up to 2 kW, combined maximum 5 kW.
-This uses multi-tag scoping: `power_limit(tags={1,2}, max=5kW)` constrains the sum of VLANs 1 and 2.
-
-## Compilation pipeline
-
-The compiler transforms policy definitions into model-layer constructs.
-
-```mermaid
-graph TD
-    A[User policy configs] --> B[Flow enumeration]
-    B --> C[Signature computation]
-    C --> D[VLAN assignment]
-    D --> E[Reachability analysis]
-    E --> F[Connection tagging]
-    F --> G[Node outbound tags]
-    G --> H[Node inbound tags]
-    H --> I[Pricing injection]
-    I --> J[Model elements]
-```
-
-### Step 1: Flow enumeration
-
-Each policy expands to concrete source-destination tuples.
-
-- `Grid -> Load: $0.05` becomes `{(Grid, Load, 0.05)}`.
-- `* -> Load: $0.05` becomes all sources paired with `Load`.
-- `Grid -> *: $0.05` becomes all destinations paired with `Grid`.
-
-### Step 2: Policy signature computation
-
-For each source node, compute a policy signature.
-A signature is the set of `(destination, price_st, price_ts)` tuples matched for that source.
-
-$$
-\text{sig}(s) = \{(d, \pi_{st}, \pi_{ts}) \mid \text{policy}(s \to d, \pi_{st}, \pi_{ts})\}
-$$
-
-### Step 3: VLAN assignment
-
-Sources with identical signatures share one VLAN.
-Sources with different signatures must use different VLANs — at least one policy treats them differently, so the optimizer must be able to distinguish them.
-The resulting VLAN count is the provably minimum: the number of distinct non-empty signatures, plus tag 0.
-
-Nodes with empty signatures use tag 0.
-When no policies exist at all, only tag 0 exists — identical to standard HAEO.
-
-### Step 4: Reachability analysis
-
-For each VLAN, compute which connections can carry it using directed reachability.
-
-1. Identify source nodes assigned to that VLAN.
-2. Compute forward reachability from those sources (following connection direction) and backward reachability from *all* sink nodes (reverse direction).
-    Forward traversal *absorbs* at sink nodes: a sink is included in the reachable set but expansion does not continue out of it. The VLAN's own sources are exempt so storage elements can still expand their own VLAN forward.
-3. Assign VLAN variables only to connections whose endpoints both appear in the intersection of forward and backward reachable sets.
-
-This avoids creating variables on impossible routes, while also ensuring a tagged source has a direct path to every sink it could physically serve.
-A policy restricts where tagged flow is *priced* (Step 8), not where it may physically terminate: narrowing the subgraph to policy destinations alone would force solar to detour through storage whenever a Solar→Grid policy exhausted grid capacity, because Load would refuse the Solar tag.
-That shows up as spurious simultaneous charge and discharge — power "laundered" through the battery to shed its provenance.
-Sink absorption closes a related hole: without it, a VLAN that reached a battery would also propagate onto the battery's outbound edge, letting foreign tags leave storage without paying costs that were priced on the battery's own VLAN — the phantom charge/discharge arbitrage that appears when a negative-priced charge incentive is paired with tag-scoped wear.
-Reachability also excludes edges whose *target* is one of the VLAN's own sources: a VLAN cannot re-enter its origin, which breaks the zero-cost self-loop `Battery:discharge → Inverter → Battery:charge → Battery` that would otherwise let solar (or any other incoming VLAN) pay only for the round-trip efficiency loss while the wear cost on the outbound cut is never crossed.
-For tree topologies, which cover most home energy systems, paths between any two nodes are unique and the computation is linear in the node count.
-
-### Step 5: Connection tagging
-
-Each connection receives all VLANs that can traverse it.
-Interior connections (trunks) can carry many VLANs.
-Endpoint connections carry only the VLANs their node produces or consumes.
-
-### Step 6: Node outbound tags
-
-Each source node gets `outbound_tags` constraining which tags it can produce on.
-Policied sources produce only on their assigned VLAN.
-Unpolicied source-capable nodes produce only on tag 0, preventing unnecessary production decomposition.
-
-### Step 7: Node inbound tags
-
-Sink nodes get `inbound_tags` listing which VLANs they can consume.
-All sinks accept tag 0 (unpolicied power) plus all active policy VLANs.
-This default-allow approach ensures both policied and unpolicied power can reach any sink.
-
-Power can still pass through a non-sink node on any VLAN for routing.
-Junction nodes (neither source nor sink) do not receive inbound tags.
-
-### Step 8: Pricing injection
-
-For each policy, compute a sink-side canonical minimum s-t cut on the per-VLAN subgraph and attach a scoped pricing segment to each connection in that cut.
-The algorithm is Edmonds–Karp max-flow with unit edge capacities; the cut is recovered by reverse BFS from the super-sink in the residual graph.
-
-Unit capacities and the sink-side choice jointly guarantee that every source-to-destination path on the VLAN crosses exactly one cut edge, so a unit of tagged flow pays the policy price exactly once — no stacking from overlapping sub-cuts, and no flows that bypass pricing.
-Minimum cardinality also means pricing is attached to the fewest connections, which matters for power-limit policies: the limit collapses to a single $\sum_{e \in \text{cut}} P^{tag}_{e,t} \le X$ constraint.
-
-The cut naturally collapses to intuitive placements:
-
-- Target-inbound edges for a specific destination (e.g. `Grid → Load` prices the `SW → Load` connection).
-- Source-outbound edges for a single-outbound source targeting a wildcard (e.g. `Battery → *` prices the single `Battery → Inverter` connection).
-- A shared bottleneck when many sources and many destinations converge through a narrower middle (e.g. an inverter separating `Solar|Battery` from `Load|Grid`).
-
-Each injected segment's `tag` matches the source VLAN, and `price_source_target` and `price_target_source` map from the policy's directional prices.
+A policy whose source list (or destination list) enumerates multiple elements applies its terms to the *sum* of the corresponding tag flows.
+Combined with single-source policies, this allows both aggregate and per-source bounds to coexist on the same physical subgraph: the aggregate bound constrains $\sum_v P^v$ while per-source bounds constrain each $P^v$ separately.
 
 ## Mathematical formulation
 
 ### Per-tag power variables
 
-Each segment creates non-negative variables per tag and period.
+Each connection carries one non-negative flow variable per direction, per tag, per period:
 
 $$
-P^{st}_{v,t} \geq 0 \quad \forall v \in \text{Tags}(c), \; t \in \{0, \ldots, T-1\}
+P^{st}_{v,e,t} \ge 0, \quad P^{ts}_{v,e,t} \ge 0
+\quad \forall v \in \text{Tags}(e), \; e \in \text{Edges}, \; t \in \{0, \ldots, T-1\}
 $$
 
-### Total power in segment constraints
+### Aggregate flow in segment constraints
 
-Segment constraints operate on aggregate directional power.
-
-$$
-P^{st}_t = \sum_{v \in \text{Tags}(c)} P^{st}_{v,t}
-$$
-
-### Per-tag node balance
-
-Node balance applies independently for each tag.
-
-- Junction nodes: $\sum_c P^{tag}_{c,t} = 0$ for each tag (routing).
-- Source nodes: only the source's own tag can have net outflow.
-- Sink nodes: only tags in the node's `inbound_tags` set can have net inflow.
-
-### Policy pricing term
-
-For policy `(source_vlan, destination, price)`, the policy cost contribution is:
+Per-connection segment constraints (capacity, pricing, efficiency) operate on the aggregate directional flow:
 
 $$
-C_{\text{policy}} = \sum_{e \in \text{cut}} \sum_t P^{st}_{v,e,t} \cdot \pi \cdot \Delta t_t
+P^{st}_{e,t} = \sum_{v \in \text{Tags}(e)} P^{st}_{v,e,t}
 $$
 
-The sum runs over the sink-side canonical minimum cut separating source from destination on the VLAN subgraph (see Step 8).
-Unit capacities guarantee each source-to-destination path crosses exactly one cut edge, so the term assesses the policy price on each unit of tagged flow exactly once.
+This keeps segment formulations tag-agnostic while preserving per-tag identity for policy-scoped constraints.
 
-## Variable count analysis
+### Per-tag balance
 
-| Scenario                          | VLANs | Connections with VLAN | Variable form                             |
-| --------------------------------- | ----- | --------------------- | ----------------------------------------- |
-| No policies                       | 1     | all x 1               | $C \times S \times 2 \times T$            |
-| One policy (`Grid -> Load`)       | 2     | partial x 2           | $< C \times 2 \times S \times 2 \times T$ |
-| All sources same policy signature | 2     | often broad           | $C \times 2 \times S \times 2 \times T$   |
-| All sources distinct signatures   | $N+1$ | varies by route       | $\sum_c K_c \times S \times 2 \times T$   |
+Node balance holds independently for each tag admitted at a node $n$:
 
-`C` is connection count, `S` is segments per connection, `T` is period count, and `K_c` is VLAN count on connection `c`.
-Signature merging and reachability pruning reduce variable growth compared with naive one-tag-per-source assignment.
+$$
+\sum_{e \in \text{out}(n)} P^{st}_{v,e,t} - \sum_{e \in \text{in}(n)} P^{st}_{v,e,t} = b_{n,v,t}
+$$
 
-## Examples
+where $b_{n,v,t}$ is the node's net production on tag $v$.
+The node-role semantics above determine which tags carry which sign of $b$:
+source-only nodes have $b > 0$ only on their own tag, sink-only nodes have $b \le 0$ on any admitted tag, and junctions have $b = 0$ for every tag.
 
-### Grid surcharge
+### Policy pricing
 
-```
-System: Grid <-> Switchboard <-> Load, Solar -> Switchboard
-Policy: Grid -> Load: $0.05/kWh
-```
+Each policy contributes a pricing term summed over its *priced edges* — the minimum edge cut on the policy's tag subgraph separating the policy's sources from its destinations:
 
-Compilation summary:
+$$
+C_{\text{policy}} = \sum_{e \in \text{cut}} \sum_t P^{st}_{v,e,t} \cdot \pi \cdot \Delta t
+$$
 
-1. Flows: `{(Grid, Load, 0.05)}`.
-2. Signatures: Grid has `{(Load, 0.05)}`, others have empty signatures.
-3. VLANs: Grid gets VLAN 1, others stay on tag 0.
-4. Reachability: VLAN 1 appears on the directed path from Grid to every sink it can reach (here just Load).
-5. Outbound tags: Grid produces on VLAN 1, Solar produces on tag 0.
-6. Inbound tags: Load accepts tag 0 and VLAN 1.
-7. Pricing: the min-cut separating Grid from Load collapses to the `SW → Load` inbound edge, which gets `pricing(tag=grid_vlan, $0.05)`.
+Unit edge capacities on the cut guarantee that every source-to-destination path on the tag crosses exactly one priced edge, so each unit of tagged flow pays $\pi$ exactly once and no path bypasses the policy.
+Power-limit policies use the same cut to enforce $\sum_{e \in \text{cut}} P^{st}_{v,e,t} \le X$; minimising the cut keeps the constraint over the fewest edges.
 
-Result:
-Grid power carries the surcharge to `Load`.
-Solar power flows freely on tag 0 at zero policy cost and is preferred when cheaper.
+## Compilation algorithm
 
-### Selective pricing
+Translating a policy set into the LP constructs above has three algorithmic stages.
 
-```
-System: Grid <-> Switchboard <-> Load, Solar -> Switchboard, Battery <-> Switchboard
-Policy: Battery -> *: $0.02/kWh
-```
+### Tag assignment by signature merging
 
-Battery gets a VLAN with a discharge wear cost.
-Solar and Grid stay on tag 0 (no policy targets them) at zero cost.
-All sink destinations accept tag 0 and Battery's VLAN, so Solar and Grid power reaches them freely.
-The wildcard destination expands to every sink reachable from Battery, and the min-cut collapses to the single `Battery → Switchboard` outbound edge — one segment carries the `$0.02/kWh` wear cost regardless of which sink ultimately consumes the power.
+Each source is summarised by its *policy signature*: the set of destination-price tuples in which it participates.
+Sources with identical signatures receive identical downstream treatment and are merged to share a tag; sources with distinct signatures require distinct tags.
+The resulting tag count is the number of distinct non-empty signatures plus one default tag, which is the provable minimum required to keep every policy distinguishable.
 
-## Implementation location
+### Reachability with absorbing sinks and source exclusion
 
-The compilation pipeline runs in `custom_components/haeo/core/adapters/policy_compilation.py`.
-It executes as a post-processing step in `collect_model_elements()` after adapter element configs are assembled.
-The model layer remains policy-unaware and operates only on tags and scoped segments.
+Each tag is assigned only to edges that can carry it on some source-to-sink path.
+Forward reachability propagates from the tag's sources; backward reachability propagates from all sink nodes; the intersection determines the edges that receive the tag.
+Two additional rules keep provenance consistent:
 
-## External and internal pricing
+- **Sink absorption.** Forward traversal stops at each sink, except when the sink is one of the tag's own sources.
+- **Source exclusion.** Edges whose target is one of the tag's own sources are removed from the result.
 
-HAEO separates external market pricing from internal valuation policies.
+Absorbing at sinks prevents a tag from propagating through a storage element and leaving under its original provenance;
+source exclusion prevents a tag from re-entering its origin via a return path, which would otherwise admit zero-cost internal loops that bypass any cost placed on an outbound cut.
 
-**External pricing** represents real market costs or credits — what you actually pay or earn.
-These belong on the element that interfaces with the external system:
+### Pricing placement by minimum s-t cut
 
-- Grid import and export prices from your energy retailer.
-- Feed-in tariff rates.
+For each policy, the pricing term is attached to the edges of the minimum s-t cut on that policy's tag subgraph between its sources and destinations.
+Unit edge capacities and the sink-side canonical cut jointly ensure every source-to-destination path crosses exactly one priced edge.
+The minimum-cardinality cut collapses naturally to intuitive placements — onto a single inbound edge when the destination has one inbound, onto a single outbound edge when the source has one outbound, and onto a shared bottleneck when sources and destinations converge through a narrower middle.
 
-External prices are configured on pricing segments and driven by sensor data.
-They are not policies.
+## Variable count
 
-**Internal policies** are valuations you choose to apply to guide the optimizer, without representing real money changing hands:
+Per connection, the number of tagged flow variables scales with the number of tags that actually reach the connection:
 
-- Battery discharge wear cost (`$0.02/kWh`).
-- Battery charge incentive (`-$0.001/kWh`).
-- Source-destination routing penalties.
+$$
+|\text{vars}(e)| = K(e) \cdot S(e) \cdot 2 \cdot T
+$$
 
-These should be configured as power policies so the cost structure is explicit: "Battery to anything costs `$0.02/kWh` because of wear."
+where $K(e)$ is the tag count on edge $e$, $S(e)$ the number of segments on that connection, and $T$ the horizon length.
+Three structural bounds shape variable growth:
 
-!!! note "Migration path"
+- In the absence of policies, $K(e) = 1$ for every edge.
+- Signature merging caps the global tag count at the number of distinct non-empty signatures plus one.
+- Reachability pruning reduces $K(e)$ on any edge that lies outside a given tag's source-to-sink subgraph.
 
-    Battery flat pricing fields (`price_source_target`, `price_target_source`) can map to policies.
-    Battery discharge cost can become `Battery -> *: $0.02/kWh`.
-    Battery charge incentive can become `* -> Battery: -$0.001/kWh`.
-    SOC-dependent valuation still requires state-dependent modeling rather than flat per-kWh policies.
+Practical variable growth therefore tracks the number of *distinguishable* policy groupings rather than the number of policies or the number of sources.
 
-## Future work: SOC-based VLANs
+## Future work: SOC-based tags
 
-Battery SOC partitions could be modeled as separate VLANs so different SOC regions carry different tags.
-That approach could enable SOC-dependent valuation through the same policy machinery.
-This remains an open modeling topic.
+State-of-charge partitioning could be expressed as separate tags assigned to different SOC regions of a storage element, enabling SOC-dependent valuation through the same tag machinery.
+This remains an open modelling direction.
 
 ## Next Steps
 
@@ -423,7 +171,7 @@ This remains an open modeling topic.
 
     ---
 
-    Review implementation details and compiler behavior.
+    Review the concrete compilation pipeline and algorithm steps.
 
     [:material-arrow-right: Policy compilation](../developer-guide/policy-compilation.md)
 

--- a/docs/user-guide/elements/node.md
+++ b/docs/user-guide/elements/node.md
@@ -77,6 +77,14 @@ The combination of `is_source` and `is_sink` determines the node's behavior:
 - Useful for modeling bidirectional power sources or flexible power exchange points
 - Similar to bidirectional grid elements but without automatic connection creation
 
+!!! info "Node role and power policies"
+
+    Source/sink flags also determine how [power policies](../../modeling/tagged-power.md) follow energy through the node.
+    Sinks terminate a policy's provenance — a `source=X → destination=Y` rule cannot see past an intermediate sink.
+    Junctions (neither source nor sink) pass provenance through unchanged, which is what lets a `Solar → Grid` policy price the whole chain through your switchboard and inverter.
+    If you are placing a routing hub between policied sources and destinations, keep it a pure junction.
+    See [Node roles and policy scope](../../modeling/tagged-power.md#node-roles-and-policy-scope) for the full rules.
+
 ## Purpose
 
 Nodes are connection hubs where power balance is enforced:

--- a/docs/walkthroughs/power-policies.md
+++ b/docs/walkthroughs/power-policies.md
@@ -138,9 +138,13 @@ Intermediate *sinks* (battery, load, grid-as-destination) terminate the provenan
 
 In practical terms:
 
-- **Junction elements** (inverters, switchboard nodes with both flags off) pass provenance through, so a policy can price the whole source-to-destination chain that runs through junctions.
-- **Sink elements** (loads, battery-when-charging) absorb the provenance. Any onward flow from a sink is re-tagged by that sink's own identity (or becomes unpolicied).
-- **Storage elements** (batteries) are both source and sink. Energy charged into a battery is accounted for separately from energy discharged out of it. Two policies are needed to price both legs — for example `Solar → Battery: -$0.001/kWh` (charge incentive) *and* `Battery → Grid: $0.10/kWh` (discharge export cost).
+- **Junction elements** (inverters, switchboard nodes with both flags off) pass provenance through.
+    A policy can price the whole source-to-destination chain that runs through junctions.
+- **Sink elements** (loads, battery-when-charging) absorb the provenance.
+    Any onward flow from a sink is re-tagged by that sink's own identity, or becomes unpolicied.
+- **Storage elements** (batteries) are both source and sink.
+    Energy charged into a battery is accounted for separately from energy discharged out of it.
+    Two policies are needed to price both legs — for example `Solar → Battery: -$0.001/kWh` (charge incentive) *and* `Battery → Grid: $0.10/kWh` (discharge export cost).
 
 If you need to route policied flow through a junction, model the junction as a plain `Node` (with `is_source=false` and `is_sink=false`) and hang the real sink/source elements off it.
 See [Node roles and policy scope](../modeling/tagged-power.md#node-roles-and-policy-scope) for the full rules.

--- a/docs/walkthroughs/power-policies.md
+++ b/docs/walkthroughs/power-policies.md
@@ -131,6 +131,20 @@ With these four policies configured, the optimizer now has detailed cost signals
 The optimizer uses these costs alongside grid import/export prices to find the cheapest overall schedule.
 For example, if grid import costs \$0.25/kWh, shipping solar to a load (free) is strongly preferred over importing from the grid.
 
+## Policy scope: where a rule actually applies
+
+A policy like `Solar → Grid: $0.02/kWh` prices solar-originated power — but only while that power still carries Solar's provenance.
+Intermediate *sinks* (battery, load, grid-as-destination) terminate the provenance, so policies do not follow energy past them.
+
+In practical terms:
+
+- **Junction elements** (inverters, switchboard nodes with both flags off) pass provenance through, so a policy can price the whole source-to-destination chain that runs through junctions.
+- **Sink elements** (loads, battery-when-charging) absorb the provenance. Any onward flow from a sink is re-tagged by that sink's own identity (or becomes unpolicied).
+- **Storage elements** (batteries) are both source and sink. Energy charged into a battery is accounted for separately from energy discharged out of it. Two policies are needed to price both legs — for example `Solar → Battery: -$0.001/kWh` (charge incentive) *and* `Battery → Grid: $0.10/kWh` (discharge export cost).
+
+If you need to route policied flow through a junction, model the junction as a plain `Node` (with `is_source=false` and `is_sink=false`) and hang the real sink/source elements off it.
+See [Node roles and policy scope](../modeling/tagged-power.md#node-roles-and-policy-scope) for the full rules.
+
 ## Next Steps
 
 <div class="grid cards" markdown>


### PR DESCRIPTION
## Summary

- Make VLAN reachability *sink-absorbing* (a sink joins the reachable set but forward traversal stops there) so tagged flow can no longer propagate through storage and launder its provenance onto the battery's outbound edge.
- Make VLAN reachability *source-excluding* (edges whose target is one of the VLAN's own sources are dropped) so a VLAN cannot re-enter its origin.  On a battery this removes `Battery:charge` from the battery's own VLAN, breaking the zero-cost self-loop `Battery:discharge → Inverter → Battery:charge → Battery`.

## Why

Combined these two holes let the solver open a profitable arbitrage loop when a negative-priced battery-charge policy (the legacy early-charge incentive migrated to `target=Battery, price=-0.001`) was paired with a tag-scoped battery-wear cost:

1. Pump tagged flow into the battery at its charge rate limit, collecting the `-$0.001/kWh` incentive on the charge connection.
2. Emerge on the discharge connection carrying a different tag, so the battery-VLAN wear cost placed on a downstream cut is never crossed.
3. Cover the 4% round-trip efficiency loss with the solar incentive; the loop is strictly profitable and saturates rate limits.

The visible symptom on `scenario6` with `Battery min sell = $1.04` (export effectively blocked) and the early-charge incentive enabled was large simultaneous charge/discharge (~17 kW on each side for many periods) plus battery fill delayed to the *last* day of the 7-day horizon, even though the secondary objective prefers earlier energy.  After the fix the battery reaches 100% SoC by period 42 on day 1, with zero simultaneous charge/discharge across the entire horizon.

## What changed

- `custom_components/haeo/core/adapters/policy_compilation.py`
  - `_find_reachable_connections` gains an `absorb_at` argument; forward BFS now tracks an `expanded` set (nodes from which expansion continued) alongside `reachable`, and only edges out of expanded nodes are emitted.  Nodes in `source_nodes` are exempt from absorption so a storage element's own VLAN can still fan out from it.
  - The returned edge set filters out edges whose target is in `source_nodes`, so a VLAN can never re-enter its origin.
  - `compile_policies` passes `absorb_at=sink_names`.
- `custom_components/haeo/core/adapters/tests/test_policy_compilation.py`
  - New unit tests: `test_find_reachable_connections_absorbs_tags_at_sinks`, `test_find_reachable_connections_does_not_absorb_at_origin`, `test_find_reachable_connections_excludes_edges_into_source`.
  - New integration tests: `test_compile_policies_absorbs_solar_tag_at_battery_sink`, `test_compile_policies_excludes_battery_self_loop_vlan`.
  - Updated the existing `_find_reachable_connections` mock to accept `**_kwargs` since callers now pass `absorb_at`.
- `docs/developer-guide/policy-compilation.md`, `docs/modeling/tagged-power.md`
  - Document the sink-absorbing and source-excluding reachability semantics and the arbitrage patterns they close.

## Test plan

- [x] `uv run pytest custom_components/haeo/core/adapters/tests/test_policy_compilation.py` (unit + integration tests for the new semantics pass)
- [x] `uv run pytest tests/scenarios/ --timeout=120` (all 6 scenario snapshots pass unchanged)
- [x] `uv run pytest --timeout=120` (full suite: 1726 passed, 2 skipped)
- [x] Manual investigation on scenario6 with the config that originally reproduced the arbitrage (`Battery min sell = 1.04`, `target=Battery, price=-0.001`): battery reaches 100% SoC by period 42 (day 1), 0 simultaneous charge/discharge periods — down from persistent 17 kW cycling and end-of-horizon fill before the fix.


Made with [Cursor](https://cursor.com)